### PR TITLE
Style cleanup

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -13,7 +13,6 @@ export class SignalElement extends HTMLElement {
   createdCallback() {
     this.update([], [])
     this.classList.add('inline-block')
-    this.classList.add('loading-spinner-tiny')
   }
   update(titles: Array<string>, history: Array<{ title: string, duration: string }>) {
     this.setBusy(!!titles.length)
@@ -46,8 +45,10 @@ export class SignalElement extends HTMLElement {
       if (timeDifference < 1000) {
         this.deactivateTimer = setTimeout(() => this.setBusy(false), timeDifference + 100)
       } else {
-        this.classList.add('idle')
-        this.classList.remove('busy')
+        this.addEventListener('animationiteration', function() {
+          this.classList.add('idle')
+          this.classList.remove('busy')
+        })
       }
     }
   }

--- a/styles/busy-signal.less
+++ b/styles/busy-signal.less
@@ -5,17 +5,46 @@
 @import "ui-variables";
 
 busy-signal {
-  margin-top: 0.4em;
+  position: relative;
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+
+  &.idle,
+  &.busy {
+    &::before {
+      content: '';
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      border-radius: 50%;
+
+      transition: background .5s linear;
+    }
+  }
+
+  &.idle {
+    &::before {
+      background: @text-color-success;
+    }
+  }
+
   &.busy {
     cursor: wait;
-    color: @text-color-warning;
-  }
-  &.idle {
-    background: radial-gradient(#64c42d .1em, transparent .11em);
+
+    &::before {
+      background-color: @text-color-warning;
+      animation: bounce 1.0s infinite ease-in-out;
+    }
   }
 }
 
-busy-signal.idle::before, busy-signal.idle::after {
-  display: none;
-  -webkit-animation: none;
+@keyframes bounce {
+  0%, 100% {
+    transform: scale(1.0);
+  } 50% {
+    transform: scale(.6);
+  }
 }


### PR DESCRIPTION
- Simplify markup;
- Fix layout (_it was not centred vertically_);
- Set colours based on the active templates;
- Add animation on `.busy` signal.

![busy-signal-enhancements](https://cloud.githubusercontent.com/assets/23187766/26740726/a5aec488-47ce-11e7-86ef-bee13bda7c9b.gif)
