### PR TITLE
Remove addEventListener

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -45,10 +45,8 @@ export class SignalElement extends HTMLElement {
       if (timeDifference < 1000) {
         this.deactivateTimer = setTimeout(() => this.setBusy(false), timeDifference + 100)
       } else {
-        this.addEventListener('animationiteration', function() {
-          this.classList.add('idle')
-          this.classList.remove('busy')
-        })
+        this.classList.add('idle')
+        this.classList.remove('busy')
       }
     }
   }


### PR DESCRIPTION
Initially introduced to make smoother the animation from Busy to IDLE, it actually caused the icon to appear IDLE even when busy.