### PR TITLE
Support atom-ide busy-signal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- support the API provided by the busy signal of the now retired atom-ide-ui package
+
 ## 1.4.3
 
 - Fix an issue with addEventListener

--- a/decls/atom-ide.js
+++ b/decls/atom-ide.js
@@ -1,0 +1,47 @@
+/* @flow */
+
+declare module "atom-ide/busy-signal" {
+  declare type BusySignalOptions = {
+    // Can say that a busy signal will only appear when a given file is open.
+    // Default = null, meaning the busy signal applies to all files.
+    onlyForFile?: string,
+    // Is user waiting for computer to finish a task? (traditional busy spinner)
+    // or is the computer waiting for user to finish a task? (action required)
+    // Default = spinner.
+    waitingFor?: "computer" | "user",
+    // Debounce it? default = true for busy-signal, and false for action-required.
+    debounce?: boolean,
+    // If onClick is set, then the tooltip will be clickable. Default = null.
+    onDidClick?: () => void,
+    // If set to true, the busy signal tooltip will be immediately revealed
+    // when it first becomes visible (without explicit mouse interaction).
+    revealTooltip?: boolean
+  };
+
+  declare type BusyMessage = {
+    // You can set/update the title.
+    setTitle(title: string): void,
+    // Dispose of the signal when done to make it go away.
+    dispose(): void
+  };
+
+  declare interface BusySignalService {
+    // Activates the busy signal with the given title and returns the promise
+    // from the provided callback.
+    // The busy signal automatically deactivates when the returned promise
+    // either resolves or rejects.
+    reportBusyWhile<T>(
+      title: string,
+      f: () => Promise<T>,
+      options?: BusySignalOptions
+    ): Promise<T>;
+
+    // Activates the busy signal. Set the title in the returned BusySignal
+    // object (you can update the title multiple times) and dispose it when done.
+    reportBusy(title: string, options?: BusySignalOptions): BusyMessage;
+
+    // This is a no-op. When someone consumes the busy service, they get back a
+    // reference to the single shared instance, so disposing of it would be wrong.
+    dispose(): void;
+  }
+}

--- a/decls/atom.js
+++ b/decls/atom.js
@@ -1,16 +1,2244 @@
-/* @flow */
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @flow
+ */
 
-declare module 'atom' {
-  declare var Emitter: any;
-  declare var Disposable: any;
-  declare var CompositeDisposable: any;
+/**
+ * Private Classes
+ */
+
+declare type IDisposable = {
+  dispose(): mixed,
+};
+
+// Octicons v4.4.0. List extracted from the atom-styleguide package.
+type atom$Octicon = 'alert' | 'alignment-align' | 'alignment-aligned-to' | 'alignment-unalign' |
+  'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-small-down' | 'arrow-small-left' |
+  'arrow-small-right' | 'arrow-small-up' | 'arrow-up' | 'beaker' | 'beer' | 'bell' | 'bold' |
+  'book' | 'bookmark' | 'briefcase' | 'broadcast' | 'browser' | 'bug' | 'calendar' | 'check' |
+  'checklist' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'circle-slash' |
+  'circuit-board' | 'clippy' | 'clock' | 'cloud-download' | 'cloud-upload' | 'code' | 'color-mode' |
+  'comment' | 'comment-add' | 'comment-discussion' | 'credit-card' | 'dash' | 'dashboard' |
+  'database' | 'desktop-download' | 'device-camera' | 'device-camera-video' | 'device-desktop' |
+  'device-mobile' | 'diff' | 'diff-added' | 'diff-ignored' | 'diff-modified' | 'diff-removed' |
+  'diff-renamed' | 'ellipses' | 'ellipsis' | 'eye' | 'eye-unwatch' | 'eye-watch' | 'file' |
+  'file-add' | 'file-binary' | 'file-code' | 'file-directory' | 'file-directory-create' |
+  'file-media' | 'file-pdf' | 'file-submodule' | 'file-symlink-directory' | 'file-symlink-file' |
+  'file-text' | 'file-zip' | 'flame' | 'fold' | 'gear' | 'gift' | 'gist' | 'gist-fork' |
+  'gist-new' | 'gist-private' | 'gist-secret' | 'git-branch' | 'git-branch-create' |
+  'git-branch-delete' | 'git-commit' | 'git-compare' | 'git-fork-private' | 'git-merge' |
+  'git-pull-request' | 'git-pull-request-abandoned' | 'globe' | 'grabber' | 'graph' | 'heart' |
+  'history' | 'home' | 'horizontal-rule' | 'hourglass' | 'hubot' | 'inbox' | 'info' |
+  'issue-closed' | 'issue-opened' | 'issue-reopened' | 'italic' | 'jersey' | 'jump-down' |
+  'jump-left' | 'jump-right' | 'jump-up' | 'key' | 'keyboard' | 'law' | 'light-bulb' | 'link' |
+  'link-external' | 'list-ordered' | 'list-unordered' | 'location' | 'lock' | 'log-in' | 'log-out' |
+  'logo-gist' | 'logo-github' | 'mail' | 'mail-read' | 'mail-reply' | 'mark-github' | 'markdown' |
+  'megaphone' | 'mention' | 'microscope' | 'milestone' | 'mirror' | 'mirror-private' |
+  'mirror-public' | 'mortar-board' | 'move-down' | 'move-left' | 'move-right' | 'move-up' | 'mute' |
+  'no-newline' | 'octoface' | 'organization' | 'package' | 'paintcan' | 'pencil' | 'person' |
+  'person-add' | 'person-follow' | 'pin' | 'playback-fast-forward' | 'playback-pause' |
+  'playback-play' | 'playback-rewind' | 'plug' | 'plus-small' | 'plus' | 'podium' |
+  'primitive-dot' | 'primitive-square' | 'pulse' | 'puzzle' | 'question' | 'quote' | 'radio-tower' |
+  'remove-close' | 'reply' | 'repo' | 'repo-clone' | 'repo-create' | 'repo-delete' |
+  'repo-force-push' | 'repo-forked' | 'repo-pull' | 'repo-push' | 'repo-sync' | 'rocket' | 'rss' |
+  'ruby' | 'screen-full' | 'screen-normal' | 'search' | 'search-save' | 'server' | 'settings' |
+  'shield' | 'sign-in' | 'sign-out' | 'smiley' | 'split' | 'squirrel' | 'star' | 'star-add' |
+  'star-delete' | 'steps' | 'stop' | 'sync' | 'tag' | 'tag-add' | 'tag-remove' | 'tasklist' |
+  'telescope' | 'terminal' | 'text-size' | 'three-bars' | 'thumbsdown' | 'thumbsup' | 'tools' |
+  'trashcan' | 'triangle-down' | 'triangle-left' | 'triangle-right' | 'triangle-up' | 'type-array'|
+  'type-boolean'| 'type-class'| 'type-constant'| 'type-constructor'| 'type-enum'| 'type-field'|
+  'type-file'| 'type-function'| 'type-interface'| 'type-method'| 'type-module'| 'type-namespace'|
+  'type-number'| 'type-package'| 'type-property'| 'type-string'| 'type-variable' | 'unfold' |
+  'unmute' | 'unverified' | 'verified' | 'versions' | 'watch' | 'x' | 'zap';
+
+type atom$PaneLocation = 'left' | 'right' | 'bottom' | 'center';
+
+declare type atom$Color  = {
+  // Returns a String in the form '#abcdef'.
+  toHexString(): string;
+  // Returns a String in the form 'rgba(25, 50, 75, .9)'.
+  toRGBAString(): string;
 }
 
-declare var it: any;
-declare var atom: any;
-declare var spyOn: any;
-declare var expect: any;
-declare var jasmine: any;
-declare var describe: any;
-declare var afterEach: any;
-declare var beforeEach: any;
+declare class atom$Model {
+  destroy(): void,
+  isDestroyed(): boolean,
+}
+
+declare class atom$Package {
+  path: string,
+  activateTime: number,
+  mainModule: any,
+  mainModulePath: string,
+  metadata: Object,
+  name: string,
+  loadTime: number,
+  getType(): 'atom' | 'textmate' | 'theme',
+  hasActivationCommands(): boolean,
+  hasActivationHooks(): boolean,
+  initializeTime: number,
+  getActivationHooks(): Array<string>,
+  onDidDeactivate(cb: () => mixed): IDisposable,
+  activateNow(): void,
+  // Undocumented
+  bundledPackage: boolean,
+  getCanDeferMainModuleRequireStorageKey(): string,
+  initializeIfNeeded(): void,
+}
+
+/**
+ * Essential Classes
+ */
+
+declare type atom$CustomEvent  = CustomEvent & {
+  originalEvent?: Event;
+}
+
+type atom$CommandCallback = (event: atom$CustomEvent) => mixed;
+
+type atom$CommandDescriptor = {
+  name: string,
+  displayName: string,
+  description?: string,
+  hiddenInCommandPalette?: boolean,
+  tags?: Array<string>,
+};
+
+type atom$CommandListener = atom$CommandCallback | {
+  displayName?: string,
+  description?: string,
+  didDispatch: atom$CommandCallback,
+};
+
+declare class atom$CommandRegistry {
+  // Methods
+  add(
+    target: string | HTMLElement,
+    commandNameOrCommands: string | {[commandName: string]: atom$CommandListener},
+    listener?: atom$CommandListener,
+    throwOnInvalidSelector?: boolean,
+  ): IDisposable,
+  dispatch(target: HTMLElement, commandName: string, detail?: Object): void,
+  onDidDispatch(callback: (event: atom$CustomEvent) => mixed): IDisposable,
+  onWillDispatch(callback: (event: atom$CustomEvent) => mixed): IDisposable,
+  findCommands(opts: {target: Node}): Array<atom$CommandDescriptor>,
+}
+
+declare class atom$CompositeDisposable {
+  constructor(...disposables: Array<IDisposable>): void,
+  dispose(): void,
+
+  add(...disposables: Array<IDisposable>): void,
+  remove(disposable: IDisposable): void,
+  clear(): void,
+}
+
+type atom$ConfigParams = {
+  saveCallback?: Object => void,
+  mainSource?: string,
+  projectHomeSchema?: atom$ConfigSchema,
+};
+
+type atom$ConfigType =
+  'boolean' | 'string' | 'integer' | 'number' |
+  'array' | 'object' | 'color' | 'any';
+
+type atom$ConfigSchema = {
+  default?: mixed,
+  description?: string,
+  enum?: Array<string | {value: string, description: string}>,
+  maximum?: number,
+  minimum?: number,
+  properties?: Object,
+  title?: string,
+  type: Array<atom$ConfigType> | atom$ConfigType,
+};
+
+declare class atom$Config {
+  defaultSettings: Object,
+  settings: Object,
+
+  // Config Subscription
+  observe(
+    keyPath: string,
+    optionsOrCallback?:
+      | {scope?: atom$ScopeDescriptorLike}
+      | (value: mixed) => void,
+    callback?: (value: mixed) => mixed,
+  ): IDisposable,
+
+  onDidChange(
+    keyPathOrCallback:
+      | string
+      | (event: {oldValue: mixed, newValue: mixed}) => mixed,
+    optionsOrCallback?:
+      | {scope?: atom$ScopeDescriptorLike}
+      | (event: {oldValue: mixed, newValue: mixed}) => mixed,
+    callback?: (event: {oldValue: mixed, newValue: mixed}) => mixed
+  ): IDisposable,
+
+  // Managing Settings
+  get(
+    keyPath?: string,
+    options?: {
+      excludeSources?: Array<string>,
+      sources?: Array<string>,
+      scope?: atom$ScopeDescriptorLike,
+    }
+  ): mixed,
+
+  set(
+    keyPath: string,
+    value: ?mixed,
+    options?: {
+      scopeSelector?: string,
+      source?: string,
+    },
+  ): boolean,
+
+  unset(
+    keyPath: string,
+    options?: {
+      scopeSelector?: string,
+      source?: string,
+    }
+  ): void,
+
+  getUserConfigPath(): string,
+
+  // Undocumented Methods
+  constructor(params?: atom$ConfigParams): atom$Config,
+  getRawValue(keyPath: ?string, options: {excludeSources?: string, sources?: string}): mixed,
+  getSchema(keyPath: string): atom$ConfigSchema,
+  save(): void,
+  setRawValue(keyPath: string, value: mixed): void,
+  setSchema(
+    keyPath: string,
+    schema: atom$ConfigSchema,
+  ): void,
+  removeAtKeyPath(keyPath: ?string, value: ?mixed): mixed,
+
+  // Used by nuclide-config to set the initial settings from disk
+  resetUserSettings(newSettings: Object, options?: {source?: string}): void,
+}
+
+declare class atom$Cursor {
+  // Cursor Marker
+  marker: atom$Marker;
+  editor: atom$TextEditor;
+
+  // Event Subscription
+  onDidChangePosition(
+    callback: (event: {
+      oldBufferPosition: atom$Point,
+      oldScreenPosition: atom$Point,
+      newBufferPosition: atom$Point,
+      newScreenPosition: atom$Point,
+      textChanged: boolean,
+      Cursor: atom$Cursor,
+    }) => mixed,
+  ): IDisposable,
+
+  // Managing Cursor Position
+  getBufferRow(): number,
+  getBufferColumn(): number,
+  getBufferPosition(): atom$Point,
+
+  // Cursor Position Details
+  // Moving the Cursor
+  moveUp(rowCount: number, {moveToEndOfSelection?: boolean}): void,
+  moveDown(rowCount: number, {moveToEndOfSelection?: boolean}): void,
+
+  // Local Positions and Ranges
+  getCurrentWordBufferRange(options?: {wordRegex: RegExp}): atom$Range,
+  getCurrentWordPrefix(): string,
+
+  // Visibility
+  // Comparing to another cursor
+  // Utilities
+  wordRegExp(options?: {includeNonWordCharacters: boolean}): RegExp,
+}
+
+declare class atom$Decoration {
+  destroy(): void,
+  onDidChangeProperties(
+    callback: (event: {oldProperties: Object, newProperties: Object}) => mixed
+    ): IDisposable,
+  onDidDestroy(callback: () => mixed): IDisposable,
+  getMarker(): atom$Marker,
+  getProperties(): Object,
+  setProperties(properties: mixed): void,
+}
+
+declare class atom$DisplayMarkerLayer {
+  destroy(): void,
+  clear(): void,
+  isDestroyed(): boolean,
+  markBufferPosition(position: atom$PointLike, options?: MarkerOptions): atom$Marker,
+  markBufferRange(range: atom$Range | atom$RangeLike, options?: MarkerOptions): atom$Marker,
+  findMarkers(options: MarkerOptions): Array<atom$Marker>,
+  getMarkers(): Array<atom$Marker>,
+  onDidUpdate(callback: () => mixed): IDisposable
+}
+
+declare class atom$LayerDecoration {
+  destroy(): void,
+  isDestroyed(): boolean,
+  getProperties(): Object,
+  setProperties(properties: mixed): void,
+  setPropertiesForMarker(marker: atom$Marker, properties: mixed): void,
+}
+
+declare class atom$Disposable {
+  constructor(disposalAction?: (...args: Array<any>) => any): void,
+  disposed: boolean,
+  dispose(): void,
+}
+
+declare class atom$Emitter {
+  static onEventHandlerException(error: any): IDisposable,
+  dispose(): void,
+  on(name: string, callback: (v: any) => mixed): IDisposable,
+  once(name: string, callback: (v: any) => mixed): IDisposable,
+  preempt(name: string, callback: (v: any) => void): IDisposable,
+  // This is a flow hack to prevent emitting more than one value.
+  // `EventEmitter` allows emitting any number of values - making this a land
+  // mine, since we tend to think of `emit` as interchangeable.
+  // This hack only works if the extra value is not `undefined`, so this isn't
+  // full-proof, but it works for most cases.
+  emit(name: string, value: any, ...no_extra_args_allowed: Array<void>): void,
+}
+
+declare class atom$Gutter {
+  name: string,
+  destroy(): void,
+  decorateMarker(
+    marker: atom$Marker,
+    options?: {type?: string, 'class'?: string, item?: Object | HTMLElement},
+  ): atom$Decoration,
+  show(): void,
+  hide(): void,
+  onDidDestroy(callback: () => void): IDisposable,
+}
+
+declare type atom$MarkerChangeEvent = {
+  oldHeadScreenPosition: atom$Point,
+  newHeadScreenPosition: atom$Point,
+  oldTailScreenPosition: atom$Point,
+  newTailScreenPosition: atom$Point,
+
+  oldHeadBufferPosition: atom$Point,
+  newHeadBufferPosition: atom$Point,
+  oldTailBufferPosition: atom$Point,
+  newTailBufferPosition: atom$Point,
+
+  isValid: boolean,
+  textChanged: boolean,
+}
+
+declare class atom$Marker {
+  destroy(): void,
+  getBufferRange(): atom$Range,
+  getStartBufferPosition(): atom$Point,
+  onDidChange(callback: (event: atom$MarkerChangeEvent) => mixed): IDisposable,
+  isValid(): boolean,
+  isDestroyed(): boolean,
+  onDidDestroy(callback: () => mixed): IDisposable,
+  getScreenRange(): atom$Range,
+  setBufferRange(
+    range: atom$RangeLike,
+    properties?: {reversed: boolean},
+  ): void,
+  id: number,
+}
+
+declare class atom$ServiceHub {
+  provide<T>(keyPath: string, version: string, service: T): IDisposable,
+  consume<T>(
+    keyPath: string,
+    versionRange: string,
+    callback: (provider: T) => mixed
+  ): IDisposable,
+}
+
+type atom$PackageMetadata = {
+  name: string,
+  version: string,
+};
+
+declare class atom$PackageManager {
+  +initialPackagesActivated: boolean,
+
+  // Event Subscription
+  onDidLoadInitialPackages(callback: () => void): IDisposable,
+  onDidActivateInitialPackages(callback: () => void): IDisposable,
+  onDidActivatePackage(callback: (pkg: atom$Package) => mixed): IDisposable,
+  onDidDeactivatePackage(callback: (pkg: atom$Package) => mixed): IDisposable,
+  onDidLoadPackage(callback: (pkg: atom$Package) => mixed): IDisposable,
+  onDidUnloadPackage(callback: (pkg: atom$Package) => mixed): IDisposable,
+  onDidTriggerActivationHook(activationHook: string, callback: () => mixed): IDisposable,
+
+  // Package system data
+  getApmPath(): string,
+  getPackageDirPaths(): Array<string>,
+
+  // General package data
+  resolvePackagePath(name: string): ?string,
+  isBundledPackage(name: string): boolean,
+
+  // Enabling and disabling packages
+  enablePackage(name: string): ?atom$Package,
+  disablePackage(name: string): ?atom$Package,
+  isPackageDisabled(name: string): boolean,
+
+  // Accessing active packages
+  getActivePackage(name: string): ?atom$Package,
+  getActivePackages(): Array<atom$Package>,
+  isPackageActive(name: string): boolean,
+  hasActivatedInitialPackages(): boolean,
+
+  // Activating and deactivating packages
+  activatePackage(name: string): Promise<atom$Package>,
+
+  // Accessing loaded packages
+  getLoadedPackage(name: string): ?atom$Package,
+  getLoadedPackages(): Array<atom$Package>,
+  isPackageLoaded(name: string): boolean,
+  hasLoadedInitialPackages(): boolean,
+
+  // Accessing available packages
+  getAvailablePackageNames(): Array<string>,
+  getAvailablePackageMetadata(): Array<atom$PackageMetadata>,
+
+  // (Undocumented.)
+  activate(): Promise<any>,
+  deactivatePackages(): Promise<void>,
+  deactivatePackage(name: string, suppressSerialization?: boolean): Promise<void>,
+  emitter: atom$Emitter,
+  loadedPackages: {[packageName: string]: atom$Package},
+  loadPackage(name: string): void,
+  loadPackages(): void,
+  serializePackage(pkg: atom$Package): void,
+  serviceHub: atom$ServiceHub,
+  packageDirPaths: Array<string>,
+  triggerActivationHook(hook: string): void,
+  triggerDeferredActivationHooks(): void,
+  unloadPackage(name: string): void,
+  unloadPackages(): void,
+}
+
+declare class atom$StyleManager {
+  // Event Subscription
+
+  // Reading Style Elements
+  getStyleElements(): Array<HTMLStyleElement>,
+
+  // Paths
+  getUserStyleSheetPath(): string,
+
+  // (Undocumented.)
+  addStyleSheet(
+    source: string,
+    params: {
+      sourcePath?: string,
+      context?: boolean,
+      priority?: number,
+      skipDeprecatedSelectorsTransformation?: boolean
+    }
+  ): IDisposable,
+}
+
+type atom$PaneSplitParams = {
+  copyActiveItem?: boolean,
+  items?: Array<Object>,
+};
+
+type atom$PaneSplitOrientation = 'horizontal' | 'vertical';
+type atom$PaneSplitSide = 'before' | 'after';
+
+// Undocumented class
+declare class atom$applicationDelegate {
+  focusWindow(): Promise<mixed>,
+  open(params: {
+    pathsToOpen: Array<string>,
+    newWindow?: boolean,
+    devMode?: boolean,
+    safeMode?: boolean,
+  }): void,
+
+  // Used by nuclide-config to replicate atom.config saveCallback
+  setUserSettings(config: atom$Config, configFilePath: string): Promise<mixed>;
+}
+
+type atom$PaneParams = {
+  activeItem?: Object,
+  applicationDelegate: atom$applicationDelegate,
+  focused?: boolean,
+  container: Object,
+  config: atom$Config,
+  notificationManager: atom$NotificationManager,
+  deserializerManager: atom$DeserializerManager,
+  items?: Array<Object>,
+  itemStackIndices?: Array<number>,
+  flexScale?: number,
+};
+
+declare class atom$Pane {
+  // Items
+  addItem(item: Object, options?: {index?: number, pending?: boolean}): Object,
+  getItems(): Array<Object>,
+  getActiveItem(): ?Object,
+  itemAtIndex(index: number): ?Object,
+  getActiveItemIndex(): number,
+  activateItem(item: Object): ?Object,
+  activateItemAtIndex(index: number): void,
+  moveItemToPane(item: Object, pane: atom$Pane, index: number): void,
+  destroyItem(item: Object, force?: boolean): Promise<boolean>,
+  itemForURI(uri: string): Object,
+
+  // Event subscriptions.
+  onDidAddItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
+  onDidRemoveItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
+  onWillRemoveItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
+  onDidDestroy(cb: () => mixed): IDisposable,
+  onDidChangeFlexScale(cb: (newFlexScale: number) => void): IDisposable,
+  onWillDestroy(cb: () => void): IDisposable,
+  observeActiveItem(cb: (item: ?Object) => void): IDisposable,
+
+  // Lifecycle
+  isActive(): boolean,
+  activate(): void,
+  destroy(): void,
+  isDestroyed(): void,
+
+  // Splitting
+  splitLeft(params?: atom$PaneSplitParams): atom$Pane,
+  splitRight(params?: atom$PaneSplitParams): atom$Pane,
+  splitUp(params?: atom$PaneSplitParams): atom$Pane,
+  splitDown(params?: atom$PaneSplitParams): atom$Pane,
+  split(
+    orientation: atom$PaneSplitOrientation,
+    side: atom$PaneSplitSide,
+    params?: atom$PaneSplitParams,
+  ): atom$Pane,
+
+  // Undocumented Methods
+  constructor(params: atom$PaneParams): atom$Pane,
+  getPendingItem(): atom$PaneItem,
+  setPendingItem(item: atom$PaneItem): void,
+  clearPendingItem(): void,
+  getFlexScale(): number,
+  getElement(): HTMLElement,
+  getParent(): Object,
+  removeItem(item: Object, moved: ?boolean): void,
+  setActiveItem(item: Object): Object,
+  setFlexScale(flexScale: number): number,
+  getContainer(): atom$PaneContainer,
+
+  element: HTMLElement,
+}
+
+declare interface atom$PaneItem {
+  // These are all covariant, meaning that these props are read-only. Therefore we can assign an
+  // object with more strict requirements to an variable of this type.
+  +getTitle: () => string,
+  +getLongTitle?: () => string,
+  +getIconName?: () => string,
+  +getURI?: () => ?string,
+  +onDidChangeIcon?: (cb: (icon: string) => void) => IDisposable,
+  +onDidChangeTitle?: (cb: (title: string) => void) => IDisposable,
+  +onDidTerminatePendingState?: (() => mixed) => IDisposable;
+  +serialize?: () => Object,
+  +terminatePendingState?: () => void,
+}
+
+// Undocumented class
+declare class atom$PaneAxis {
+  getFlexScale(): number,
+  setFlexScale(flexScale: number): number,
+  getItems(): Array<Object>,
+}
+
+// Undocumented class
+// Note that this is not the same object returned by `atom.workspace.getPaneContainers()`. (Those
+// are typed here as AbstractPaneContainers and, in the current implementation, wrap these.)
+declare class atom$PaneContainer {
+  constructor({
+    config: atom$Config,
+    applicationDelegate: atom$applicationDelegate,
+    notificationManager: atom$NotificationManager,
+    deserializerManager: atom$DeserializerManager,
+  }): atom$PaneContainer,
+  destroy(): void,
+  getActivePane(): atom$Pane,
+  getActivePaneItem(): ?Object,
+  getLocation(): atom$PaneLocation,
+  getPanes(): Array<atom$Pane>,
+  getPaneItems(): Array<atom$PaneItem>,
+  observePanes(cb: (pane: atom$Pane) => void): IDisposable,
+  onDidAddPane(cb: (event: {pane: atom$Pane}) => void): IDisposable,
+  onDidDestroyPane(cb: (event: {pane: atom$Pane}) => void): IDisposable,
+  onWillDestroyPane(cb: (event: {pane: atom$Pane}) => void): IDisposable,
+  onDidAddPaneItem(cb: (item: atom$PaneItem) => void): IDisposable,
+  onDidDestroyPaneItem(cb: (item: atom$Pane) => void): IDisposable,
+  paneForItem(item: Object): ?atom$Pane,
+  serialize(): Object,
+}
+
+declare class atom$Panel {
+  // Construction and Destruction
+  destroy(): void,
+
+  // Event Subscription
+  onDidChangeVisible(callback: (visible: boolean) => any): IDisposable,
+  onDidDestroy(callback: (panel: atom$Panel) => any): IDisposable,
+
+  // Panel Details
+  getElement(): HTMLElement,
+  getItem(): any,
+  getPriority(): number,
+  isVisible(): boolean,
+  hide(): void,
+  show(): void,
+}
+
+type atom$PointObject = {row: number, column: number};
+
+type atom$PointLike = atom$Point
+| [number, number]
+| atom$PointObject;
+
+declare class atom$Point {
+  static fromObject(object: atom$PointLike, copy: ? boolean): atom$Point,
+  constructor(row: number, column: number): void,
+  row: number,
+  column: number,
+  copy(): atom$Point,
+  negate(): atom$Point,
+
+  // Comparison
+  min(point1: atom$PointLike, point2: atom$PointLike): atom$Point,
+  compare(other: atom$PointLike): -1 | 0 | 1,
+  isEqual(otherRange: atom$PointLike): boolean,
+  isLessThan(other: atom$PointLike): boolean,
+  isLessThanOrEqual(other: atom$PointLike): boolean,
+  isGreaterThan(other: atom$PointLike): boolean,
+  isGreaterThanOrEqual(other: atom$PointLike): boolean,
+
+  // Operations
+  translate(other: atom$PointLike): atom$Point,
+
+  // Conversion
+  serialize(): [number, number],
+  toArray(): [number, number],
+}
+
+type atom$RangeObject = {
+  start: atom$PointObject,
+  end: atom$PointObject,
+};
+
+type atom$RangeLike = atom$Range
+  | atom$RangeObject // TODO: Flow doesn't really handle the real signature below...
+  | [atom$PointLike, atom$PointLike]
+  | {
+    start: atom$PointLike,
+    end: atom$PointLike,
+  };
+
+declare class atom$Range {
+  static fromObject(
+    object: atom$RangeLike,
+    copy?: boolean,
+  ): atom$Range,
+  constructor(pointA: atom$PointLike, pointB: atom$PointLike): void,
+  compare(other: atom$Range): number,
+  start: atom$Point,
+  end: atom$Point,
+  isEmpty(): boolean,
+  isEqual(otherRange: atom$RangeLike): boolean,
+  intersectsWith(otherRange: atom$RangeLike, exclusive?: boolean): boolean,
+  containsPoint(point: atom$PointLike, exclusive?: boolean): boolean,
+  containsRange(other: atom$Range, exclusive?: boolean): boolean,
+  union(other: atom$Range): atom$Range,
+  serialize(): Array<Array<number>>,
+  translate(startDelta: atom$PointLike, endDelta?: atom$PointLike): atom$Range,
+  getRowCount(): number,
+  getRows(): Array<number>,
+}
+
+type RawStatusBarTile = {
+  item: HTMLElement,
+  priority: number,
+};
+
+type atom$StatusBarTile = {
+  getPriority(): number,
+  getItem(): HTMLElement,
+  destroy(): void,
+};
+
+declare class atom$ScopeDescriptor {
+  constructor(object: {scopes: Array<string>}): void,
+  getScopesArray(): Array<string>,
+}
+
+type atom$ScopeDescriptorLike = atom$ScopeDescriptor | Array<string>;
+
+/**
+ * This API is defined at https://github.com/atom/status-bar.
+ */
+declare class atom$StatusBar {
+  addLeftTile(tile: RawStatusBarTile): atom$StatusBarTile,
+  addRightTile(tile: RawStatusBarTile): atom$StatusBarTile,
+  getLeftTiles(): Array<atom$StatusBarTile>,
+  getRightTiles(): Array<atom$StatusBarTile>,
+}
+
+// https://github.com/atom/atom/blob/v1.9.0/src/text-editor-registry.coffee
+declare class atom$TextEditorRegistry {
+  add(editor: atom$TextEditor): IDisposable,
+  remove(editor: atom$TextEditor): boolean,
+  observe(callback: (editor: atom$TextEditor) => void): IDisposable,
+  build: (params: atom$TextEditorParams) => atom$TextEditor,
+
+  // Private
+  editors: Set<atom$TextEditor>,
+}
+
+declare class atom$ThemeManager {
+  // Event Subscription
+  /**
+   * As recent as Atom 1.0.10, the implementation of this method was:
+   *
+   * ```
+   * onDidChangeActiveThemes: (callback) ->
+   *   @emitter.on 'did-change-active-themes', callback
+   *   @emitter.on 'did-reload-all', callback # TODO: Remove once deprecated pre-1.0 APIs are gone
+   * ```
+   *
+   * Due to the nature of CoffeeScript, onDidChangeActiveThemes returns a Disposable even though it
+   * is not documented as doing so. However, the Disposable that it does return removes the
+   * subscription on the 'did-reload-all' event (which is supposed to be deprecated) rather than the
+   * 'did-change-active-themes' one.
+   */
+  onDidChangeActiveThemes(callback: () => mixed): IDisposable,
+
+  // Accessing Loaded Themes
+  getLoadedThemeNames(): Array<string>,
+  getLoadedThemes(): Array<mixed>, // TODO: Define undocumented ThemePackage class.
+
+  // Accessing Active Themes
+  getActiveThemeNames(): Array<string>,
+  getActiveThemes(): Array<mixed>, // TODO: Define undocumented ThemePackage class.
+
+  // Managing Enabled Themes
+  getEnabledThemeNames(): Array<string>,
+
+  // Private
+  activateThemes(): Promise<any>,
+  requireStylesheet(stylesheetPath: string): IDisposable,
+}
+
+type atom$TooltipsPlacementOption = 'top' | 'bottom' | 'left' | 'right' | 'auto';
+
+type atom$TooltipsAddOptions = {
+  title?: string,
+  item?: HTMLElement,
+  keyBindingCommand?: string,
+  keyBindingTarget?: HTMLElement,
+  animation?: boolean,
+  container?: string | false,
+  delay?: number | {show: number, hide: number},
+  placement?: atom$TooltipsPlacementOption | () => atom$TooltipsPlacementOption,
+  trigger?: string,
+};
+
+type atom$Tooltip = {
+  show(): void;
+  hide(): void;
+  getTooltipElement(): HTMLElement,
+};
+
+declare class atom$TooltipManager {
+  tooltips: Map<HTMLElement, Array<atom$Tooltip>>;
+  add(
+    target: HTMLElement,
+    options: atom$TooltipsAddOptions,
+  ): IDisposable,
+  findTooltips(HTMLElement): Array<atom$Tooltip>,
+}
+
+type InsertTextOptions = {
+  select: boolean,
+  autoIndent: boolean,
+  autoIndentNewline: boolean,
+  autoDecreaseIndent: boolean,
+  normalizeLineEndings: ?boolean,
+  undo: string,
+};
+
+type DecorateMarkerParams = {
+  type: 'line',
+  class: string,
+  onlyHead?: boolean,
+  onlyEmpty?: boolean,
+  onlyNonEmpty?: boolean,
+} | {
+  type: 'gutter',
+  item?: HTMLElement,
+  class?: string,
+  onlyHead?: boolean,
+  onlyEmpty?: boolean,
+  onlyNonEmpty?: boolean,
+  gutterName?: string,
+} | {
+  type: 'highlight',
+  class?: string,
+  gutterName?: string,
+} | {
+  type: 'overlay',
+  item: Object,
+  position?: 'head' | 'tail', // Defaults to 'head' when unspecified.
+} | {
+  type: 'block',
+  item: HTMLElement,
+  position?: 'before' | 'after', // Defaults to 'before' when unspecified.
+} | {
+  type: 'line-number',
+  class?: string,
+};
+
+type ChangeCursorPositionEvent = {
+  oldBufferPosition: atom$Point,
+  oldScreenPosition: atom$Point,
+  newBufferPosition: atom$Point,
+  newScreenPosition: atom$Point,
+  textChanged: boolean,
+  cursor: atom$Cursor,
+};
+
+type MarkerOptions = {
+  reversed?: boolean,
+  tailed?: boolean,
+  invalidate?: 'never' | 'surround' | 'overlap' | 'inside' | 'touch',
+  exclusive?: boolean,
+};
+
+type atom$ChangeSelectionRangeEvent = {|
+  oldBufferRange: atom$Range,
+  oldScreenRange: atom$Range,
+  newBufferRange: atom$Range,
+  newScreenRange: atom$Range,
+  selection: atom$Selection,
+|};
+
+declare class atom$TextEditor extends atom$Model {
+  id: number,
+  verticalScrollMargin: number,
+
+  // Event Subscription
+  onDidChange(callback: () => void): IDisposable,
+  onDidChangePath(callback: (newPath: string) => mixed): IDisposable,
+  onDidStopChanging(callback: () => mixed): IDisposable,
+  onDidChangeCursorPosition(callback: (event: ChangeCursorPositionEvent) => mixed):
+    IDisposable,
+  onDidAddCursor(callback: (cursor: atom$Cursor) => mixed): IDisposable;
+  onDidRemoveCursor(callback: (cursor: atom$Cursor) => mixed): IDisposable;
+  onDidDestroy(callback: () => mixed): IDisposable,
+  onDidSave(callback: (event: {path: string}) => mixed): IDisposable,
+  getBuffer(): atom$TextBuffer,
+  observeGrammar(callback: (grammar: atom$Grammar) => mixed): IDisposable,
+  onWillInsertText(callback: (event: {cancel: () => void, text: string}) => void):
+      IDisposable,
+  // Note that the range property of the event is undocumented.
+  onDidInsertText(callback: (event: {text: string, range: atom$Range}) => mixed): IDisposable,
+  onDidChangeSoftWrapped(callback: (softWrapped: boolean) => mixed): IDisposable,
+  onDidChangeSelectionRange(callback: (event: atom$ChangeSelectionRangeEvent) => mixed): IDisposable,
+  observeSelections(callback: (selection: atom$Selection) => mixed): IDisposable,
+
+  // File Details
+  getTitle: () => string,
+  getLongTitle(): string,
+  /**
+   * If you open Atom via Spotlight such that it opens with a tab named
+   * "untitled" that does not correspond to a file on disk, this will return
+   * null.
+   */
+  getPath(): ?string,
+  getURI: () => ?string,
+  insertNewline(): void,
+  isModified: () => boolean,
+  isEmpty(): boolean,
+  getEncoding(): buffer$Encoding,
+  setEncoding(encoding: string): void,
+  getTabLength() : number,
+  getSoftTabs(): boolean,
+  getIconName(): string,
+  onDidChangeIcon(cb: (icon: string) => void): IDisposable,
+  onDidChangeTitle(cb: (title: string) => void): IDisposable,
+
+  // File Operations
+  save(): Promise<void>,
+  // DO NOT USE: Doesn't work with remote text buffers!
+  // saveAs(filePath: string): void,
+
+  // Reading Text
+  getText(): string,
+  getTextInBufferRange(range: atom$RangeLike): string,
+  getLineCount(): number,
+  getScreenLineCount(): number,
+  getLastScreenRow(): number,
+
+  // Mutating Text
+  setText(text: string, options?: InsertTextOptions): void,
+  setTextInBufferRange(
+    range: atom$RangeLike,
+    text: string,
+    options?: {
+      normalizeLineEndings?: boolean,
+      undo?: string,
+    },
+  ): atom$Range,
+  insertText(text: string): Array<atom$Range> | false,
+  mutateSelectedText(fn: (selection: atom$Selection, index: number) => void): void,
+  delete: () => void,
+  backspace: () => void,
+  duplicateLines: () => void,
+
+  // History
+  createCheckpoint(): atom$TextBufferCheckpoint,
+  revertToCheckpoint(checkpoint: atom$TextBufferCheckpoint): boolean,
+  terminatePendingState(): void,
+  transact(fn: () => mixed, _: void): void,
+  transact(groupingInterval: number, fn: () => mixed): void,
+  onDidTerminatePendingState(() => mixed): IDisposable;
+
+  // TextEditor Coordinates
+  screenPositionForBufferPosition(
+    bufferPosition: atom$PointLike,
+    options?: {
+      wrapBeyondNewlines?: boolean,
+      wrapAtSoftNewlines?: boolean,
+      screenLine?: boolean,
+    },
+  ): atom$Point,
+  bufferPositionForScreenPosition(
+    screenPosition: atom$PointLike,
+    options?: {
+      wrapBeyondNewlines?: boolean,
+      wrapAtSoftNewlines?: boolean,
+      screenLine?: boolean,
+    },
+  ): atom$Point,
+  getEofBufferPosition(): atom$Point,
+  getVisibleRowRange(): [number, number],
+  bufferRowForScreenRow(screenRow: number): number,
+  screenRangeForBufferRange(bufferRange: atom$RangeLike): atom$Range,
+
+  // Decorations
+  decorateMarker(marker: atom$Marker, decorationParams: DecorateMarkerParams): atom$Decoration,
+  decorateMarkerLayer(
+    markerLayer: atom$DisplayMarkerLayer,
+    decorationParams: DecorateMarkerParams,
+  ): atom$LayerDecoration,
+  decorationsForScreenRowRange(
+    startScreenRow: number,
+    endScreenRow: number,
+  ): {[markerId: string]: Array<Object>},
+  getDecorations(options?: {class?: string, type?: string}): Array<atom$Decoration>,
+
+  // Markers
+  addMarkerLayer(): atom$DisplayMarkerLayer,
+  getDefaultMarkerLayer(): atom$DisplayMarkerLayer,
+  markBufferPosition(position: atom$PointLike, options?: MarkerOptions): atom$Marker,
+  markBufferRange(range: atom$RangeLike, options?: MarkerOptions): atom$Marker,
+  markScreenRange(range: atom$RangeLike, options?: MarkerOptions): atom$Marker,
+  markScreenPosition(position: atom$PointLike, options?: MarkerOptions): atom$Marker,
+  findMarkers(options: MarkerOptions): Array<atom$Marker>,
+  getMarkerCount(): number,
+
+  // Cursors
+  getCursors(): Array<atom$Cursor>,
+  setCursorBufferPosition(
+    position: atom$PointLike,
+    options?: {
+      autoscroll?: boolean,
+      wrapBeyondNewlines?: boolean,
+      wrapAtSoftNewlines?: boolean,
+      screenLine?: boolean,
+    }): void,
+  getCursorBufferPosition(): atom$Point,
+  getCursorBufferPositions(): Array<atom$Point>,
+  getCursorScreenPosition(): atom$Point,
+  getCursorScreenPositions(): Array<atom$Point>,
+  getLastCursor(): atom$Cursor,
+  addCursorAtBufferPosition(point: atom$PointLike): atom$Cursor,
+  moveToBeginningOfLine(): void,
+  moveToEndOfLine(): void,
+  moveToBottom(): void,
+
+  // Folds
+  foldCurrentRow(): void,
+  unfoldCurrentRow(): void,
+  foldBufferRow(bufferRow: number): void,
+  unfoldBufferRow(bufferRow: number): void,
+
+  // Selections
+  getSelectedText(): string,
+  selectAll(): void,
+  getSelectedBufferRange(): atom$Range,
+  getSelectedBufferRanges(): Array<atom$Range>,
+  getSelections(): Array<atom$Selection>,
+  selectToBufferPosition(point: atom$Point): void,
+  setSelectedBufferRange(
+    bufferRange: atom$RangeLike,
+    options?: {
+      reversed?: boolean,
+      preserveFolds?: boolean,
+    },
+  ): void,
+  setSelectedBufferRanges(
+    bufferRanges: Array<atom$Range>,
+    options?: {
+      reversed?: boolean,
+      preserveFolds?: boolean,
+    },
+  ): void,
+  selectWordsContainingCursors(): void,
+
+  // Folds
+  unfoldAll(): void,
+
+  // Searching and Replacing
+  scanInBufferRange(
+    regex: RegExp,
+    range: atom$Range,
+    iterator: (foundMatch: {
+      match: mixed,
+      matchText: string,
+      range: atom$Range,
+      stop: () => mixed,
+      replace: (replaceWith: string) => mixed,
+    }) => mixed
+  ): void,
+
+  scan(
+    regex: RegExp,
+    iterator: (foundMatch: {
+      match: mixed,
+      matchText: string,
+      range: atom$Range,
+      stop: () => mixed,
+      replace: (replaceWith: string) => mixed,
+    }) => mixed
+  ): void,
+
+  // Tab Behavior
+  // Soft Wrap Behavior
+  // Indentation
+  indentationForBufferRow(bufferRow: number): number,
+  setTabLength(tabLength: number): void,
+  setSoftTabs(softTabs: boolean): void,
+
+  lineTextForBufferRow(bufferRow: number): string,
+  lineTextForScreenRow(screenRow: number): string,
+
+  // Grammars
+  getGrammar(): atom$Grammar,
+  setGrammar(grammar: ?atom$Grammar): void,
+
+  // Clipboard Operations
+  pasteText: (options?: Object) => void,
+  copySelectedText: () => void,
+
+  // Managing Syntax Scopes
+  getRootScopeDescriptor(): atom$ScopeDescriptor,
+  scopeDescriptorForBufferPosition(
+    bufferPosition: atom$PointLike,
+  ): atom$ScopeDescriptor,
+
+  // Gutter
+  addGutter(options: {
+    name: string,
+    priority?: number,
+    visible?: boolean,
+  }): atom$Gutter,
+  observeGutters(callback: (gutter: atom$Gutter) => void): IDisposable,
+  getGutters(): Array<atom$Gutter>,
+  gutterWithName(name: string): ?atom$Gutter,
+
+  // Scrolling the TextEditor
+  scrollToBufferPosition(
+    position: atom$Point | [?number, ?number],
+    options?: {center?: boolean}
+  ): void,
+  scrollToScreenPosition(
+    position: atom$Point | [?number, ?number],
+    options?: {center?: boolean}
+  ): void,
+  scrollToScreenRange(screenRange: atom$Range, options?: {clip?: boolean}): void,
+  scrollToCursorPosition(
+    options?: {center?: boolean}
+  ): void,
+  scrollToBottom(): void,
+  scrollToTop(): void,
+
+  // TextEditor Rendering
+  getPlaceholderText(): string,
+  setPlaceholderText(placeholderText: string): void,
+
+  // This is undocumented, but Nuclide uses it in the AtomTextEditor wrapper.
+  setLineNumberGutterVisible(lineNumberGutterVisible: boolean): void,
+
+  // Editor Options
+  setSoftWrapped(softWrapped: boolean): void,
+
+  isFoldedAtBufferRow(row: number): boolean,
+  getLastBufferRow(): number,
+
+  // Undocumented Methods
+  getElement(): atom$TextEditorElement,
+  getDefaultCharWidth(): number,
+  getLineHeightInPixels(): number,
+  moveToTop(): void,
+  tokenForBufferPosition(position: atom$Point | [?number, ?number]): atom$Token,
+  onDidConflict(callback: () => void): IDisposable,
+  serialize(): Object,
+  foldBufferRowRange(startRow: number, endRow: number): void,
+  getNonWordCharacters(position?: atom$PointLike): string,
+  scheduleComponentUpdate(): void,
+}
+
+/**
+ * This is not part of the official Atom 1.0 API. Nevertheless, we need to reach into this object
+ * via `atom$TextEditorElement` to do some things that we have no other way to do.
+ */
+declare class atom$TextEditorComponent {
+  domNode: HTMLElement,
+  scrollViewNode: HTMLElement,
+  presenter: atom$TextEditorPresenter,
+  refs: atom$TextEditorComponentRefs,
+  linesComponent: atom$LinesComponent,
+  // NOTE: This is typed as a property to allow overwriting.
+  startCursorBlinking: () => void,
+  stopCursorBlinking(): void,
+  pixelPositionForScreenPosition(
+    screenPosition: atom$Point,
+    clip?: boolean,
+  ): {top: number, left: number},
+  screenPositionForMouseEvent(event: MouseEvent): atom$Point,
+  pixelPositionForMouseEvent(
+    event: MouseEvent,
+    linesClientRect?: {top: number, left: number, bottom: number, right: number},
+  ): {top: number, left: number, bottom: number, right: number},
+  invalidateBlockDecorationDimensions(decoration: atom$Decoration): void,
+  element: atom$TextEditorElement,
+  didFocus(): void,
+  setScrollTop(scrollTop: number): void,
+  getScrollTop(): number,
+
+  setScrollLeft(scrollLeft: number): void,
+  getScrollLeft(): number,
+  updateSync(useScheduler?: boolean): void,
+}
+
+/**
+ * This is not part of the official Atom 1.0 API. Nevertheless, we need to reach into this object
+ * via `atom$TextEditorComponent` to do some things that we have no other way to do.
+ */
+declare class atom$TextEditorPresenter {
+  startBlinkingCursors: () => void,
+  stopBlinkingCursors(visible: boolean): void,
+  updateLineNumberGutterState(): void,
+}
+
+/**
+ * This is not part of the official Atom 1.0 API. Nevertheless, we need it to access
+ * the deepest dom element receiving DOM events.
+ */
+declare class atom$LinesComponent {
+  domNode: HTMLElement,
+  getDomNode(): HTMLElement,
+}
+
+/**
+ * This is not part of the official Atom 1.0 API. Nevertheless, we need it to access
+ * the deepest dom element receiving DOM events.
+ */
+declare class atom$TextEditorComponentRefs {
+  lineTiles: HTMLElement,
+}
+
+/**
+ * This is not part of the official Atom 1.0 API, but it really should be. This is the element that
+ * is returned when you run `atom.views.getView(<TextEditor>)`.
+ */
+declare class atom$TextEditorElement extends HTMLElement {
+  component: ?atom$TextEditorComponent,
+  getModel(): atom$TextEditor,
+  setModel(model: atom$TextEditor): void,
+  pixelPositionForBufferPosition(
+    bufferPosition: atom$PointLike,
+  ): {top: number, left: number},
+  pixelPositionForScreenPosition(screenPosition: atom$Point): {
+    left: number,
+    top: number,
+  },
+
+  setScrollTop(scrollTop: number): void,
+  getScrollTop(): number,
+
+  setScrollLeft(scrollLeft: number): void,
+  getScrollLeft(): number,
+
+  getScrollHeight(): number,
+  getHeight(): number,
+
+  onDidChangeScrollTop(callback: (scrollTop: number) => mixed): IDisposable,
+  onDidChangeScrollLeft(callback: (scrollLeft: number) => mixed): IDisposable,
+
+  // Called when the editor is attached to the DOM.
+  onDidAttach(callback: () => mixed): IDisposable,
+  // Called when the editor is detached from the DOM.
+  onDidDetach(callback: () => mixed): IDisposable,
+
+  measureDimensions(): void,
+
+  // Undocumented Methods
+
+  // Returns a promise that resolves after the next update.
+  getNextUpdatePromise(): Promise<void>,
+
+  // `undefined` means no explicit width. `null` sets a zero width (which is almost certainly a
+  // mistake) so we don't allow it.
+  setWidth(width: number | void): void,
+}
+
+declare class atom$ViewProvider {
+  modelConstructor: Function,
+}
+
+declare class atom$ViewRegistry {
+  // Methods
+  addViewProvider(
+    modelConstructor: any,
+    createView?: (...args: Array<any>) => ?HTMLElement
+  ): IDisposable,
+  getView(textEditor: atom$TextEditor): atom$TextEditorElement,
+  getView(notification: atom$Notification): HTMLElement,
+  getView(gutter: atom$Gutter): HTMLElement,
+  getView(panel: atom$Panel): HTMLElement,
+  getView(workspace: atom$Workspace): HTMLElement,
+  getView(object: Object): HTMLElement,
+  providers: Array<atom$ViewProvider>,
+}
+
+type atom$WorkspaceAddPanelOptions = {
+  item: Object,
+  visible?: boolean,
+  priority?: number,
+  className?: string,
+};
+
+type atom$TextEditorParams = {
+  buffer?: atom$TextBuffer,
+  lineNumberGutterVisible?: boolean,
+};
+
+type DestroyPaneItemEvent = {
+  item: atom$PaneItem,
+  pane: atom$Pane,
+  index: number,
+};
+
+type AddPaneItemEvent = {
+  item: atom$PaneItem,
+  pane: atom$Pane,
+  index: number,
+};
+
+type OnDidOpenEvent = {
+  uri: string,
+  item: mixed,
+  pane: atom$Pane,
+  index: number,
+};
+
+type AddTextEditorEvent = {
+  textEditor: atom$TextEditor,
+  pane: atom$Pane,
+  index: number,
+};
+
+type atom$WorkspaceOpenOptions = {
+  activatePane?: ?boolean,
+  activateItem?: ?boolean,
+  initialLine?: ?number,
+  initialColumn?: ?number,
+  pending?: ?boolean,
+  split?: ?string,
+  searchAllPanes?: ?boolean,
+  location?: atom$PaneLocation,
+}
+
+declare class atom$Workspace {
+  // Event Subscription
+  observePanes(cb: (pane: atom$Pane) => void): IDisposable,
+  observeTextEditors(callback: (editor: atom$TextEditor) => mixed): IDisposable,
+  observeActiveTextEditor(callback: (editor: ?atom$TextEditor) => mixed): IDisposable,
+  onDidAddTextEditor(callback: (event: AddTextEditorEvent) => mixed): IDisposable,
+  onDidChangeActivePaneItem(callback: (item: mixed) => mixed): IDisposable,
+  onDidDestroyPaneItem(callback: (event: DestroyPaneItemEvent) => mixed): IDisposable,
+  onDidAddPaneItem(callback: (event: AddPaneItemEvent) => mixed): IDisposable,
+  observeActivePaneItem(callback: (item: ?mixed) => mixed): IDisposable,
+  onDidStopChangingActivePaneItem(callback: (item: ?mixed) => mixed): IDisposable,
+  observePaneItems(callback: (item: mixed) => mixed): IDisposable,
+  onWillDestroyPaneItem(
+    callback: (event: {item: mixed, pane: mixed, index: number}) => mixed
+  ): IDisposable,
+  onDidOpen(callback: (event: OnDidOpenEvent) => mixed): IDisposable,
+
+  getElement(): HTMLElement,
+
+  // Opening
+  open(
+    uri?: string,
+    options?: atom$WorkspaceOpenOptions,
+  ): Promise<atom$TextEditor>,
+  openURIInPane(
+    uri?: string,
+    pane: atom$Pane,
+    options?: {
+      initialLine?: number,
+      initialColumn?: number,
+      activePane?: boolean,
+      searchAllPanes?: boolean,
+    }
+  ): Promise<atom$TextEditor>,
+  isTextEditor(item: ?mixed): boolean,
+  /* Optional method because this was added post-1.0. */
+  buildTextEditor: ((params: ?atom$TextEditorParams) => atom$TextEditor),
+  /* Optional method because this was added in 1.9.0 */
+  handleGrammarUsed?: (grammar: atom$Grammar) => void,
+  reopenItem(): Promise<?atom$TextEditor>,
+  addOpener(callback: (uri: string) => any): IDisposable,
+  hide(uriOrItem: string | Object): void,
+  toggle(uriOrItem: string | Object): void,
+
+  // Pane Containers
+  getPaneContainers(): Array<atom$AbstractPaneContainer>,
+  paneContainerForItem(item: ?mixed): ?atom$AbstractPaneContainer,
+
+  // Pane Items
+  getPaneItems(): Array<Object>,
+  getActivePaneItem(): ?Object,
+  getActivePaneContainer(): atom$PaneContainer,
+  getTextEditors(): Array<atom$TextEditor>,
+  getActiveTextEditor(): ?atom$TextEditor,
+  createItemForURI(uri: string, options: atom$WorkspaceOpenOptions): atom$PaneItem,
+
+  // Panes
+  getPanes(): Array<atom$Pane>,
+  getActivePane(): atom$Pane,
+  activateNextPane(): boolean,
+  activatePreviousPane(): boolean,
+  paneForURI(uri: string): atom$Pane,
+  paneForItem(item: mixed): ?atom$Pane,
+  paneContainers: {[location: atom$PaneLocation]: atom$AbstractPaneContainer},
+
+  // Panels
+  panelContainers: {[location: string]: atom$PanelContainer},
+  getBottomPanels(): Array<atom$Panel>,
+  addBottomPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+  getLeftPanels(): Array<atom$Panel>,
+  addLeftPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+  getRightPanels(): Array<atom$Panel>,
+  addRightPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+  getTopPanels(): Array<atom$Panel>,
+  addTopPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+  getModalPanels(): Array<atom$Panel>,
+  addModalPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+  getHeaderPanels(): Array<atom$Panel>,
+  addHeaderPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+
+  getLeftDock(): atom$Dock,
+  getRightDock(): atom$Dock,
+  getBottomDock(): atom$Dock,
+  getCenter(): atom$WorkspaceCenter,
+
+  // Searching and Replacing
+  scan(
+    regex: RegExp,
+    options: {
+      paths?: Array<string>,
+      onPathsSearched?: (numSearched: number) => mixed,
+      leadingContextLineCount?: number,
+      trailingContextLineCount?: number,
+    },
+    iterator: (
+      ?{
+        filePath: string,
+        matches: Array<{
+          leadingContextLines: Array<string>,
+          lineText: string,
+          lineTextOffset: number,
+          range: atom$RangeLike,
+          matchText: string,
+          trailingContextLines: Array<string>,
+        }>,
+      },
+      Error,
+    ) => mixed,
+  ): Promise<?string>,
+
+  destroyActivePaneItemOrEmptyPane(): void,
+  destroyActivePaneItem(): void,
+}
+
+declare class atom$AbstractPaneContainer {
+  activate(): void,
+  getLocation(): atom$PaneLocation,
+  getElement(): HTMLElement,
+  isVisible(): boolean,
+  show(): void,
+  hide(): void,
+  getActivePane(): atom$Pane,
+  getPanes(): Array<atom$Pane>,
+  onDidAddPaneItem((item: {item: Object}) => void): IDisposable,
+  observePanes(cb: (pane: atom$Pane) => void): IDisposable,
+  state: {
+    size: number,
+  }
+}
+
+declare class atom$Dock extends atom$AbstractPaneContainer {
+  // This is a woefully incomplete list, items can be added as needed from
+  // https://github.com/atom/atom/blob/master/src/dock.js
+  toggle(): void,
+}
+
+declare class atom$WorkspaceCenter extends atom$AbstractPaneContainer {
+  activate(): void;
+
+  // Pane Items
+  getPaneItems(): Array<atom$PaneItem>,
+  getActivePaneItem(): ?atom$PaneItem,
+  getTextEditors(): Array<atom$TextEditor>,
+  getActiveTextEditor(): ?atom$TextEditor,
+
+  observeActivePaneItem(callback: atom$PaneItem => mixed): IDisposable;
+  onDidChangeActivePaneItem(callback: (item: mixed) => mixed): IDisposable;
+  onDidAddTextEditor(
+    callback: (item: {
+      textEditor: atom$TextEditor,
+      pane: atom$Pane,
+      index: number,
+    }) => mixed,
+  ): IDisposable;
+  // This should be removed soon anyway, it's currently deprecated.
+  paneContainer: Object;
+}
+
+/**
+ * Extended Classes
+ */
+
+declare class atom$BufferedNodeProcess { }
+
+declare class atom$BufferedProcess {
+  // Event Subscription
+  onWillThrowError(
+    callback: (errorObject: {error: Object, handle: mixed}) => mixed
+  ): IDisposable,
+  // Helper Methods
+  kill(): void,
+}
+
+declare class atom$Clipboard {
+  // Methods
+  write(text: string, metadata?: mixed): void,
+  read(): string,
+  readWithMetadata(): {
+    metadata: ?mixed,
+    text: string,
+  },
+}
+
+declare class atom$ContextMenuManager {
+  add(itemsBySelector: {[cssSelector: string]: Array<atom$ContextMenuItem>}): IDisposable,
+  itemSets: Array<atom$ContextMenuItemSet>,
+
+  // Undocumented methods
+  showForEvent(event: Event): void,
+  templateForEvent(event: Event): Array<Object>,
+}
+
+declare class atom$ContextMenuItemSet {
+  items: Array<atom$ContextMenuItem>,
+  selector: string,
+}
+
+type atom$ContextMenuItem = {
+  command?: string,
+  created?: (event: MouseEvent) => void,
+  enabled?: boolean,
+  label?: string,
+  shouldDisplay?: (event: MouseEvent) => boolean,
+  submenu?: Array<atom$ContextMenuItem>,
+  type?: string,
+  visible?: boolean,
+};
+
+type atom$Deserializer = {
+  name: string,
+  deserialize: (state: Object) => mixed,
+};
+
+declare class atom$DeserializerManager {
+  add(...deserializers: Array<atom$Deserializer>): IDisposable,
+  deserialize(state: Object, params?: Object): mixed,
+}
+
+// Apparently it can sometimes include a `code` property.
+declare class atom$GetEntriesError extends Error {
+  code?: string,
+}
+
+declare class atom$Directory {
+  constructor(dirname?: string): atom$Directory,
+
+  symlink: boolean,
+
+  // Construction
+  create(mode?: number): Promise<boolean>,
+
+  // Event Subscription
+  onDidChange(callback: () => mixed): IDisposable,
+
+  // Directory Metadata
+  isFile(): boolean,
+  isDirectory(): boolean,
+  exists():Promise<boolean>,
+
+  // Managing Paths
+  getPath(): string,
+  getBaseName(): string,
+  relativize(fullPath: string): string,
+
+  // Event Subscription
+  onDidRename(callback: () => void): IDisposable,
+  onDidDelete(callback: () => void): IDisposable,
+
+  // Traversing
+  getParent(): atom$Directory,
+  getFile(filename: string): atom$File,
+  getSubdirectory(dirname: string): atom$Directory,
+  getEntries(
+    callback: (
+      error: ?atom$GetEntriesError,
+      entries: ?Array<atom$Directory | atom$File>,
+    ) => mixed): void,
+  contains(path: string): boolean,
+}
+
+// These are the methods called on a file by atom-text-buffer
+interface atom$Fileish {
+  existsSync(): boolean,
+  setEncoding(encoding: string): void,
+  getEncoding(): ?string,
+
+  onDidRename(callback: () => void): IDisposable,
+  onDidDelete(callback: () => void): IDisposable,
+  onDidChange(callback: () => void): IDisposable,
+  onWillThrowWatchError(callback: () => mixed): IDisposable,
+
+  getPath(): string,
+  getBaseName(): string,
+
+  createReadStream(): stream$Readable,
+  createWriteStream(): stream$Writable,
+}
+
+declare class atom$File /* implements atom$Fileish */ {
+  constructor(filePath?: string, symlink?: boolean): atom$File,
+
+  symlink: boolean,
+
+  // Construction
+  create(): Promise<boolean>,
+
+  // File Metadata
+  isFile(): boolean,
+  isDirectory(): boolean,
+  exists(): Promise<boolean>,
+  existsSync(): boolean,
+  setEncoding(encoding: string): void,
+  getEncoding(): string,
+
+  // Event Subscription
+  onDidRename(callback: () => void): IDisposable,
+  onDidDelete(callback: () => void): IDisposable,
+  onDidChange(callback: () => void): IDisposable,
+  onWillThrowWatchError(callback: () => mixed): IDisposable,
+
+  // Managing Paths
+  getPath(): string,
+  getBaseName(): string,
+
+  // Traversing
+  getParent(): atom$Directory,
+
+  // Reading and Writing
+  read(flushCache?: boolean): Promise<string>,
+  write(text: string): Promise<void>,
+  writeSync(text: string): void,
+  createReadStream(): stream$Readable,
+  createWriteStream(): stream$Writable,
+}
+
+declare class atom$GitRepository extends atom$Repository {
+  // Unofficial API.
+  statuses: {[filePath: string]: number},
+  // Return the `git-utils` async repo.
+  getRepo(): atom$GitRepositoryInternal,
+}
+
+declare class atom$Grammar {
+  name: string,
+  scopeName: string,
+  tokenizeLines(text: string): Array<Array<atom$GrammarToken>>,
+  tokenizeLine(line: string, ruleStack: mixed, firstLine: boolean): {
+    line: string,
+    tags: Array<number>,
+    // Dynamic property: invoking it will incur additional overhead
+    tokens: Array<atom$GrammarToken>,
+    ruleStack: mixed
+  },
+}
+
+type atom$GrammarToken = {
+  value: string,
+  scopes: Array<string>,
+};
+
+declare class atom$GrammarRegistry {
+  // Event Subscription
+  onDidAddGrammar(callback: (grammar: atom$Grammar) => void): IDisposable,
+
+  // Managing Grammars
+  grammarForScopeName(scopeName: string): ?atom$Grammar,
+  removeGrammarForScopeName(scopeName: string): ?atom$Grammar,
+  loadGrammarSync(grammarPath: string): atom$Grammar,
+  selectGrammar(filePath: string, fileContents: string): atom$Grammar,
+  autoAssignLanguageMode(buffer: atom$TextBuffer): void,
+  assignLanguageMode(buffer: atom$TextBuffer, languageId: string): void,
+
+  // Extended
+  getGrammarScore(grammar: atom$Grammar, filePath: string, contents?: string): number,
+  forEachGrammar(callback: (grammar: atom$Grammar) => mixed): void,
+
+  // Private API
+  clear(): IDisposable,
+}
+
+declare class atom$HistoryManager {
+  removeProject(paths: Array<string>): void,
+  getProjects(): Array<atom$HistoryProject>,
+}
+
+declare class atom$HistoryProject {
+  get paths(): Array<string>;
+  get lastOpened(): Date;
+}
+
+// https://github.com/atom/atom-keymap/blob/18f00ac307de5770bb8f98958bd9a13ecffa9e68/src/key-binding.coffee
+declare class atom$KeyBinding {
+  cachedKeyups: ?Array<string>,
+  command: string,
+  index: number,
+  keystrokeArray : Array<string>,
+  keystrokeCount: number,
+  keystrokes: string,
+  priority: number,
+  selector: string,
+  source: string,
+  specificity: number,
+
+  matches(keystroke: string): boolean,
+  compare(keybinding: atom$KeyBinding): number,
+  getKeyups(): ?Array<string>,
+  matchesKeystrokes(userKeystrokes: Array<string>): boolean | 'exact' | 'partial' | 'pendingKeyup',
+}
+
+declare class atom$KeymapManager {
+  // Event Subscription
+  onDidMatchBinding(callback: (event: {
+    keystrokes: string,
+    binding: atom$KeyBinding,
+    keyboardEventTarget: HTMLElement,
+  }) => mixed): IDisposable,
+
+  onDidPartiallyMatchBinding(callback: (event: {
+    keystrokes: string,
+    partiallyMatchedBindings: atom$KeyBinding,
+    keyboardEventTarget: HTMLElement,
+  }) => mixed): IDisposable,
+
+  onDidFailToMatchBinding(callback: (event: {
+    keystrokes: string,
+    partiallyMatchedBindings: atom$KeyBinding,
+    keyboardEventTarget: HTMLElement,
+  }) => mixed): IDisposable,
+
+  onDidFailToReadFile(callback: (error: {
+    message: string,
+    stack: string,
+  }) => mixed): IDisposable,
+
+  // Adding and Removing Bindings
+  add(source: string, bindings: Object): IDisposable,
+  removeBindingsFromSource(source: string): void,
+
+  // Accessing Bindings
+  getKeyBindings(): Array<atom$KeyBinding>,
+  findKeyBindings(params: {
+    keystrokes?: string,
+    command?: string,
+    target?: HTMLElement,
+  }): Array<atom$KeyBinding>,
+
+  // Managing Keymap Files
+  loadKeymap(path: string, options?: {watch: boolean}): void,
+  watchKeymap(path: string): void,
+
+  // Managing Keyboard Events
+  handleKeyboardEvent(event: Event): void,
+  keystrokeForKeyboardEvent(event: Event): string,
+  getPartialMatchTimeout(): number,
+
+  static buildKeydownEvent(
+    key: string,
+    options: {
+      target: HTMLElement,
+      alt?: boolean,
+      cmd?: boolean,
+      ctrl?: boolean,
+      shift?: boolean,
+    },
+  ): Event,
+}
+
+declare class atom$MenuManager {
+  add(items: Array<Object>): IDisposable,
+  update(): void,
+
+  // Private API
+  template: Array<Object>,
+}
+
+type atom$ProjectSpecification = {
+  originPath: string,
+  paths?: Array<string>,
+  config?: {[string]: mixed}
+};
+
+declare class atom$Project {
+  // Event Subscription
+  onDidChangePaths(callback: (projectPaths: Array<string>) => mixed): IDisposable,
+  onDidAddBuffer(callback: (buffer: atom$TextBuffer) => mixed): IDisposable,
+  onDidReplace((settings: atom$ProjectSpecification) => mixed): IDisposable,
+  observeBuffers(callback: (buffer: atom$TextBuffer) => mixed): IDisposable,
+  replace?: (newSettings: atom$ProjectSpecification) => void,
+  // Accessing the git repository
+  getRepositories(): Array<?atom$Repository>,
+  repositoryForDirectory(directory: atom$Directory): Promise<?atom$Repository>,
+
+  // Managing Paths
+  getPaths(): Array<string>,
+  addPath(projectPath: string, options?: {
+    emitEvent?: boolean,
+    exact?: boolean,
+    mustExist?: boolean,
+  }): void,
+  setPaths(paths: Array<string>): void,
+  removePath(projectPath: string): void,
+  getDirectories(): Array<atom$Directory>,
+  relativizePath(relativizePath?: string): Array<string>, // [projectPath: ?string, relativePath: string]
+  relativize(filePath: string): string,
+  contains(path: string): boolean,
+
+  // Private API
+  findBufferForPath(path: string): ?atom$TextBuffer,
+  addBuffer(buffer: atom$TextBuffer): void,
+  removeBuffer(buffer: atom$TextBuffer): void,
+  getBuffers(): Array<atom$TextBuffer>,
+}
+
+type TextBufferScanIterator = (arg: {
+  match: Array<string>,
+  matchText: string,
+  range: atom$Range,
+  stop(): void,
+  replace(replacement: string): void,
+}) => void;
+
+// This happens to be a number but it would be better if the type could be entirely opaque. All you
+// need to know is that if something needs a checkpoint you should only pass it values received from
+// TextBuffer::createCheckpoint
+type atom$TextBufferCheckpoint = number;
+
+// TextBuffer did-change/will-change
+type atom$TextEditEvent = {
+  oldRange: atom$Range,
+  newRange: atom$Range,
+  oldText: string,
+  newText: string,
+};
+
+type atom$AggregatedTextEditEvent = {
+  changes: Array<atom$TextEditEvent>,
+};
+
+declare class atom$LanguageMode {
+  getLanguageId(): string,
+}
+
+declare class atom$TextBuffer {
+  constructor(text?: string): atom$TextBuffer,
+  constructor(params?: {
+    filePath?: string,
+    text?: string,
+  }): atom$TextBuffer,
+
+  file: ?atom$File,
+
+  // Mixin
+  static deserialize: (state: Object, params: Object) => mixed,
+  static load: (file: string | atom$Fileish, params: Object) => Promise<atom$TextBuffer>,
+
+  setFile(file: atom$Fileish): void,
+
+  // Events
+  onWillChange(callback: () => mixed): IDisposable,
+  onDidChangeText(callback: (event: atom$AggregatedTextEditEvent) => mixed): IDisposable,
+  onDidStopChanging(callback: () => mixed): IDisposable,
+  onDidConflict(callback: () => mixed): IDisposable,
+  onDidChangeModified(callback: () => mixed): IDisposable,
+  onDidUpdateMarkers(callback: () => mixed): IDisposable,
+  onDidCreateMarker(callback: () => mixed): IDisposable,
+  onDidChangePath(callback: () => mixed): IDisposable,
+  onDidChangeEncoding(callback: () => mixed): IDisposable,
+  onWillSave(callback: () => mixed): IDisposable,
+  onDidSave(callback: (event: {path: string}) => mixed): IDisposable,
+  onDidDelete(callback: () => mixed): IDisposable,
+  onWillReload(callback: () => mixed): IDisposable,
+  onDidReload(callback: () => mixed): IDisposable,
+  onDidDestroy(callback: () => mixed): IDisposable,
+  onWillThrowWatchError(callback: () => mixed): IDisposable,
+
+  // File Details
+  // DO NOT USE (T21363106): Doesn't work with remote text buffers!
+  // setPath(filePath: string): void,
+  getPath(): ?string,
+  setEncoding(encoding: string): void,
+  getEncoding(): string,
+  getUri(): string,
+  getId(): string,
+  getLanguageMode(): atom$LanguageMode,
+
+  // Reading Text
+  isEmpty(): boolean,
+  getText(): string,
+  getTextInRange(range: atom$RangeLike): string,
+  getLineCount(): number,
+  getLines(): Array<string>,
+  getLastLine(): string,
+  lineForRow(row: number): string,
+  lineEndingForRow(row: number): string,
+  lineLengthForRow(row: number): number,
+  isRowBlank(row: number): boolean,
+  previousNonBlankRow(startRow: number): ?number,
+  nextNonBlankRow(startRow: number): ?number,
+
+  // Mutating Text
+  setText: (text: string) => atom$Range,
+  setTextInRange(range: atom$RangeLike, text: string, options?: Object): atom$Range,
+  setTextViaDiff(text: string): void,
+  insert(
+    position: atom$Point,
+    text: string,
+    options?: {
+      normalizeLineEndings?: boolean,
+      undo?: string,
+    },
+  ): atom$Range,
+  append(text: string, options: ?{
+    normalizeLineEndings?: boolean,
+    undo?: string,
+  }): atom$Range,
+  delete(range: atom$Range): atom$Range,
+  deleteRows(startRow: number, endRow: number): atom$Range,
+
+  // History
+  undo(): void,
+  redo(): void,
+  transact(fn: () => mixed, _: void): void,
+  transact(groupingInterval: number, fn: () => mixed): void,
+  clearUndoStack(): void,
+  createCheckpoint(): atom$TextBufferCheckpoint,
+  revertToCheckpoint(checkpoint: atom$TextBufferCheckpoint): boolean,
+  groupChangesSinceCheckpoint(checkpoint: atom$TextBufferCheckpoint): boolean,
+  // TODO describe the return type more precisely.
+  getChangesSinceCheckpoint(checkpoint: atom$TextBufferCheckpoint): Array<mixed>,
+
+  // Search And Replace
+  scan(regex: RegExp, iterator: TextBufferScanIterator): void,
+  scanInRange(regex: RegExp, range: atom$Range, iterator: TextBufferScanIterator): void,
+  backwardsScanInRange(regex: RegExp, range: atom$Range, iterator: TextBufferScanIterator): void,
+
+  // Buffer Range Details
+  getLastRow(): number,
+  getRange(): atom$Range,
+  rangeForRow(row: number, includeNewLine?: boolean): atom$Range,
+  getLength(): number,
+
+  // Position/Index mapping
+  characterIndexForPosition(position: atom$PointLike): number,
+  positionForCharacterIndex(index: number): atom$Point,
+
+  // Buffer Operations
+  reload(): void,
+  load(): Promise<void>,
+  save(): Promise<void>,
+
+  isInConflict(): boolean,
+  isModified(): boolean,
+
+  // Private APIs
+  cachedDiskContents: ?string,
+  emitter: atom$Emitter,
+  refcount: number,
+  loaded: boolean,
+  wasModifiedBeforeRemove: boolean,
+  finishLoading(): atom$TextBuffer,
+  updateCachedDiskContents(flushCache?: boolean, callback?: () => mixed): Promise<void>,
+  emitModifiedStatusChanged(changed: boolean): void,
+  destroy(): void,
+  isDestroyed(): boolean,
+  applyChange: () => void,
+  shouldDestroyOnFileDelete?: () => boolean,
+}
+
+declare class atom$Notification {
+  // Event Subscription
+  onDidDismiss(callback: () => mixed): IDisposable,
+  onDidDisplay(callback: () => mixed): IDisposable,
+
+  // Methods
+  getType(): string,
+  getMessage(): string,
+  getOptions(): Object,
+  dismiss(): void,
+  isDismissed(): boolean,
+}
+
+type atom$NotificationButton = {
+  text: string,
+  className?: string,
+  onDidClick?: () => mixed,
+};
+
+type atom$NotificationOptions = {
+  detail?: string,
+  dismissable?: boolean,
+  description?: string,
+  icon?: string,
+  stack?: string,
+  buttons?: Array<atom$NotificationButton>,
+};
+
+declare class atom$NotificationManager {
+  // Events
+  onDidAddNotification(callback: (notification: atom$Notification) => void): IDisposable,
+
+  // Adding Notifications
+  add(type: string, message: string, options?: atom$NotificationOptions): atom$Notification,
+  addSuccess(message: string, options?: atom$NotificationOptions): atom$Notification,
+  addInfo(message: string, options?: atom$NotificationOptions): atom$Notification,
+  addWarning(message: string, options?: atom$NotificationOptions): atom$Notification,
+  addError(message: string, options?: atom$NotificationOptions): atom$Notification,
+  addFatalError(message: string, options?: atom$NotificationOptions): atom$Notification,
+  addNotification(notification: atom$Notification): atom$Notification,
+
+  // Getting Notifications
+  getNotifications(): Array<atom$Notification>,
+}
+
+// The items in this declaration are available off of `require('atom')`.
+// This list is not complete.
+declare module 'atom' {
+  declare var BufferedNodeProcess: typeof atom$BufferedNodeProcess;
+  declare var BufferedProcess: typeof atom$BufferedProcess;
+  declare var CompositeDisposable: typeof atom$CompositeDisposable;
+  declare var Directory: typeof atom$Directory;
+  declare var Disposable: typeof atom$Disposable;
+  declare var Emitter: typeof atom$Emitter;
+  declare var File: typeof atom$File;
+  declare var GitRepository: typeof atom$GitRepository;
+  declare var Notification: typeof atom$Notification;
+  declare var Point: typeof atom$Point;
+  declare var Range: typeof atom$Range;
+  declare var TextBuffer: typeof atom$TextBuffer;
+  declare var TextEditor: typeof atom$TextEditor;
+}
+
+// Make sure that common types can be referenced without the `atom$` prefix
+// in type declarations.
+declare var Cursor: typeof atom$Cursor;
+declare var Panel: typeof atom$Panel;
+declare var TextEditor: typeof atom$TextEditor;
+
+type atom$UnhandledErrorEvent = {
+  originalError: Object,
+  message: string,
+  url: string,
+  line: number,
+  column: number,
+};
+
+// The properties of this type match the properties of the `atom` global.
+// This list is not complete.
+type AtomGlobal = {
+  // Properties
+  appVersion: string,
+  atomScriptMode: ?boolean, // Added by nuclide-atom-script.
+  clipboard: atom$Clipboard,
+  commands: atom$CommandRegistry,
+  config: atom$Config,
+  contextMenu: atom$ContextMenuManager,
+  applicationDelegate: atom$applicationDelegate,
+  deserializers: atom$DeserializerManager,
+  grammars: atom$GrammarRegistry,
+  history: atom$HistoryManager,
+  keymaps: atom$KeymapManager,
+  menu: atom$MenuManager,
+  notifications: atom$NotificationManager,
+  packages: atom$PackageManager,
+  styles: atom$StyleManager,
+  themes: atom$ThemeManager,
+  textEditors: atom$TextEditorRegistry,
+  tooltips: atom$TooltipManager,
+  views: atom$ViewRegistry,
+  workspace: atom$Workspace,
+  project: atom$Project,
+  devMode: boolean,
+
+  // Event Subscription
+  onWillThrowError(callback: (event: atom$UnhandledErrorEvent) => mixed): IDisposable,
+  onDidThrowError(callback: (event: atom$UnhandledErrorEvent) => mixed): IDisposable,
+  whenShellEnvironmentLoaded(callback: () => mixed): IDisposable,
+
+  // Atom Details
+  inDevMode(): boolean,
+  inSafeMode(): boolean,
+  inSpecMode(): boolean,
+  getVersion(): string,
+  isReleasedVersion(): boolean,
+  getWindowLoadTime(): number,
+
+  // This is an undocumented way to reach the Electron BrowserWindow.
+  // Use `electron.remote.getCurrentWindow` instead.
+  getCurrentWindow: void,
+
+  // Messaging the User
+  +confirm:
+    & ((
+      {
+        message: string,
+        detail?: string,
+        buttons?: Array<string>,
+      },
+      (number) => void,
+    ) => void)
+    // The synchronous form. You really shouldn't use this.
+    & (({
+        message: string,
+        detailedMessage?: string,
+        buttons?: Array<string> | {[buttonName: string]: () => mixed},
+      }) => ?number),
+
+  open(params: {
+    pathsToOpen?: Array<string>,
+    newWindow?: boolean,
+    devMode?: boolean,
+    safeMode?: boolean,
+  }): void,
+  reload(): void,
+
+  // Undocumented Methods
+  getConfigDirPath(): string,
+  showSaveDialogSync(options: Object): string,
+  loadState(): Promise<?Object>,
+  getLoadSettings(): Object,
+};
+
+declare var atom: AtomGlobal;
+
+type RepositoryDidChangeStatusCallback = (event: {path: string, pathStatus: number}) => mixed;
+type RepositoryLineDiff = {
+  oldStart: number,
+  newStart: number,
+  oldLines: number,
+  newLines: number,
+};
+
+// Taken from the interface of [`GitRepository`][1], which is also implemented by
+// `HgRepositoryClient`.
+//
+// [1]: https://github.com/atom/atom/blob/v1.7.3/src/git-repository.coffee
+declare class atom$Repository {
+  constructor(path: string, options?: {refreshOnWindowFocus?: boolean}): void,
+
+  // Event Subscription
+  onDidChangeStatus: (callback: RepositoryDidChangeStatusCallback) => IDisposable,
+  onDidChangeStatuses: (callback: () => mixed) => IDisposable,
+
+  // Repository Details
+  getType: () => string,
+  getPath: () => string,
+  getWorkingDirectory: () => string,
+  isProjectAtRoot: () => boolean,
+  relativize: (aPath: string) => string,
+  getOriginURL: (aPath: ?string) => ?string,
+
+  // Reading Status
+  isPathModified: (aPath: string) => boolean,
+  isPathNew: (aPath: string) => boolean,
+  isPathIgnored: (aPath: string) => boolean,
+  getDirectoryStatus: (aPath: string) => number,
+  getPathStatus: (aPath: string) => number,
+  getCachedPathStatus: (aPath: string) => ?number,
+  isStatusModified: (status: number) => boolean,
+  isStatusNew: (status: number) => boolean,
+  refreshStatus: () => Promise<void>,
+
+  // Retrieving Diffs
+  getDiffStats: (filePath: string) => {added: number, deleted: number},
+  getLineDiffs: (aPath: string, text: string) => Array<RepositoryLineDiff>,
+
+  // Checking Out
+  checkoutHead: (aPath: string) => boolean,
+  checkoutReference: (reference: string, create: boolean) => Promise<void>,
+
+  // Event Subscription
+  onDidDestroy(callback: () => mixed): IDisposable,
+  isDestroyed(): boolean,
+}
+
+declare class atom$GitRepositoryInternal {
+  // Reading Status
+  isStatusModified: (status: number) => boolean,
+  isStatusNew: (status: number) => boolean,
+  isStatusIgnored: (status: number) => boolean,
+  isStatusStaged: (status: number) => boolean,
+  isStatusDeleted: (status: number) => boolean,
+}
+
+// One of text or snippet is required.
+// TODO(hansonw): use a union + intersection type
+type atom$AutocompleteSuggestion = {
+  text?: string,
+  snippet?: string,
+  displayText?: string,
+  replacementPrefix?: string,
+  type?: ?string,
+  leftLabel?: ?string,
+  leftLabelHTML?: ?string,
+  rightLabel?: ?string,
+  rightLabelHTML?: ?string,
+  className?: ?string,
+  iconHTML?: ?string,
+  description?: ?string,
+  descriptionMarkdown?: ?string,
+  descriptionMoreURL?: ?string,
+};
+
+type atom$AutocompleteRequest = {
+  editor: TextEditor,
+  bufferPosition: atom$Point,
+  scopeDescriptor: atom$ScopeDescriptor,
+  prefix: string,
+  activatedManually?: boolean,
+};
+
+type atom$AutocompleteProvider = {
+  +selector: string,
+  +getSuggestions: (
+    request: atom$AutocompleteRequest,
+  ) => Promise<?Array<atom$AutocompleteSuggestion>> | ?Array<atom$AutocompleteSuggestion>,
+  +getSuggestionDetailsOnSelect?: (
+    suggestion: atom$AutocompleteSuggestion
+  ) => Promise<?atom$AutocompleteSuggestion>,
+  +disableForSelector?: string,
+  +inclusionPriority?: number,
+  +excludeLowerPriority?: boolean,
+  +suggestionPriority?: number,
+  +filterSuggestions?: boolean,
+  +disposable?: () => void,
+  +onDidInsertSuggestion?: (
+    insertedSuggestion: atom$SuggestionInsertedRequest,
+  ) => void,
+};
+
+type atom$SuggestionInsertedRequest = {
+  +editor: atom$TextEditor,
+  +triggerPosition: atom$Point,
+  +suggestion: atom$AutocompleteSuggestion,
+};
+
+// https://github.com/atom/autocomplete-plus/blob/master/README.md#the-watcheditor-api
+type atom$AutocompleteWatchEditor = (
+  editor: atom$TextEditor,
+  labels?: Array<string>,
+) => IDisposable;
+
+// Undocumented API.
+declare class atom$Token {
+  value: string,
+  matchesScopeSelector(selector: string): boolean,
+}
+
+declare class atom$Selection {
+  clear(): void,
+  getText(): string,
+  getBufferRange(): atom$Range,
+  insertText(
+    text: string,
+    options?: {
+      select?: boolean,
+      autoIndent?: boolean,
+      autoIndentNewLine?: boolean,
+      autoDecreaseIdent?: boolean,
+      normalizeLineEndings?: boolean,
+      undo?: boolean,
+    },
+  ): string,
+}
+
+declare class atom$PanelContainer {
+  dock: atom$Dock,
+  element: HTMLElement,
+  emitter: atom$Emitter,
+  location: atom$PaneLocation,
+  panels: Array<atom$Panel>,
+  subscriptions: atom$CompositeDisposable,
+  viewRegistry: atom$ViewRegistry,
+
+  getPanels(): Array<atom$Panel>,
+};

--- a/decls/jasmine.js
+++ b/decls/jasmine.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-declare var atom: any;
-
 declare function describe(description: string, specDefinitions: () => void): void;
 declare function xdescribe(description: string, specDefinitions: () => void): void;
 

--- a/decls/jasmine.js
+++ b/decls/jasmine.js
@@ -1,0 +1,339 @@
+/* @flow */
+
+declare var atom: any;
+
+declare function describe(description: string, specDefinitions: () => void): void;
+declare function xdescribe(description: string, specDefinitions: () => void): void;
+
+declare function it(expectation: string, assertion: (done: (err?: any) => void) => void): void;
+declare function xit(expectation: string, assertion: () => void): void;
+
+declare function beforeEach(action: () => void): void;
+declare function afterEach(action: () => void): void;
+
+declare function expect(actual: any): JasmineMatchers;
+
+declare function spyOn(object: any, method: string): JasmineSpy;
+
+declare function runs(asyncMethod: Function): void;
+declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;
+declare function waits(timeout?: number): void;
+
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  createSpy(name?: string): JasmineSpy,
+  any(val: mixed): void,
+  anything(): void,
+  objectContaining(val: Object): void,
+  arrayContaining(val: mixed[]): void,
+  stringMatching(val: string): void,
+  clock(): JasmineClock,
+};
+
+type JasmineAny = {
+  jasmineMatches(other: any): boolean;
+  jasmineToString(): string;
+}
+
+type JasmineObjectContaining = {
+  jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
+  jasmineToString(): string;
+}
+
+type JasmineBlock = {
+  execute(onComplete: () => void): void;
+}
+
+type JasmineWaitsBlock = {
+} & JasmineBlock
+
+type JasmineWaitsForBlock = {
+} & JasmineBlock
+
+type JasmineClock = {
+  reset(): void;
+  tick(millis: number): void;
+  runFunctionsWithinRange(oldMillis: number, nowMillis: number): void;
+  scheduleFunction(timeoutKey: any, funcToCall: () => void, millis: number, recurring: boolean): void;
+  useMock(): void;
+  installMock(): void;
+  uninstallMock(): void;
+  real: void;
+  assertInstalled(): void;
+  isInstalled(): boolean;
+  installed: any;
+}
+
+type JasmineEnv = {
+  setTimeout: any;
+  clearTimeout: void;
+  setInterval: any;
+  clearInterval: void;
+  updateInterval: number;
+
+  currentSpec: JasmineSpec;
+
+  matchersClass: JasmineMatchers;
+
+  version(): any;
+  versionString(): string;
+  nextSpecId(): number;
+  addReporter(reporter: JasmineReporter): void;
+  execute(): void;
+  describe(description: string, specDefinitions: () => void): JasmineSuite;
+  beforeEach(beforeEachFunction: () => void): void;
+  currentRunner(): JasmineRunner;
+  afterEach(afterEachFunction: () => void): void;
+  xdescribe(desc: string, specDefinitions: () => void): JasmineXSuite;
+  it(description: string, func: () => void): JasmineSpec;
+  xit(desc: string, func: () => void): JasmineXSpec;
+  compareRegExps_(a: RegExp, b: RegExp, mismatchKeys: string[], mismatchValues: string[]): boolean;
+  compareObjects_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
+  equals_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
+  contains_(haystack: any, needle: any): boolean;
+  addEqualityTester(equalityTester: (a: any, b: any, env: JasmineEnv, mismatchKeys: string[], mismatchValues: string[]) => boolean): void;
+  specFilter(spec: JasmineSpec): boolean;
+}
+
+type JasmineFakeTimer = {
+  reset(): void;
+  tick(millis: number): void;
+  runFunctionsWithinRange(oldMillis: number, nowMillis: number): void;
+  scheduleFunction(timeoutKey: any, funcToCall: () => void, millis: number, recurring: boolean): void;
+}
+
+type JasmineHtmlReporter = {
+}
+
+type JasmineResult = {
+  type: string;
+}
+
+type JasmineNestedResults = {
+  description: string;
+
+  totalCount: number;
+  passedCount: number;
+  failedCount: number;
+
+  skipped: boolean;
+
+  rollupCounts(result: JasmineNestedResults): void;
+  log(values: any): void;
+  getItems(): JasmineResult[];
+  addResult(result: JasmineResult): void;
+  passed(): boolean;
+} & JasmineResult
+
+type JasmineMessageResult = {
+  values: any;
+  trace: JasmineTrace;
+} & JasmineResult
+
+type JasmineExpectationResult = {
+  matcherName: string;
+  passed(): boolean;
+  expected: any;
+  actual: any;
+  message: string;
+  trace: JasmineTrace;
+} & JasmineResult
+
+type JasmineTrace = {
+  name: string;
+  message: string;
+  stack: any;
+}
+
+type JasminePrettyPrinter = {
+  format(value: any): void;
+  iterateObject(obj: any, fn: (property: string, isGetter: boolean) => void): void;
+  emitScalar(value: any): void;
+  emitString(value: string): void;
+  emitArray(array: any[]): void;
+  emitObject(obj: any): void;
+  append(value: any): void;
+}
+
+type JasmineStringPrettyPrinter = {
+} & JasminePrettyPrinter
+
+type JasmineQueue = {
+  env: JasmineEnv;
+  ensured: boolean[];
+  blocks: JasmineBlock[];
+  running: boolean;
+  index: number;
+  offset: number;
+  abort: boolean;
+
+  addBefore(block: JasmineBlock, ensure?: boolean): void;
+  add(block: any, ensure?: boolean): void;
+  insertNext(block: any, ensure?: boolean): void;
+  start(onComplete?: () => void): void;
+  isRunning(): boolean;
+  next_(): void;
+  results(): JasmineNestedResults;
+}
+
+type JasmineMatchers = {
+  env: JasmineEnv;
+  actual: any;
+  spec: JasmineEnv;
+  isNot?: boolean;
+  message(): any;
+
+  toBe(expected: any): boolean;
+  toEqual(expected: any): boolean;
+  toMatch(expected: any): boolean;
+  toBeDefined(): boolean;
+  toBeUndefined(): boolean;
+  toBeNull(): boolean;
+  toBeNaN(): boolean;
+  toBeTruthy(): boolean;
+  toBeFalsy(): boolean;
+  toHaveBeenCalled(): boolean;
+  toHaveBeenCalledWith(...params: any[]): boolean;
+  toContain(expected: any): boolean;
+  toBeLessThan(expected: any): boolean;
+  toBeGreaterThan(expected: any): boolean;
+  toBeCloseTo(expected: any, precision: any): boolean;
+  toContainHtml(expected: string): boolean;
+  toContainText(expected: string): boolean;
+  toThrow(expected?: any): boolean;
+  not: JasmineMatchers;
+
+  Any: JasmineAny;
+}
+
+type JasmineReporter = {
+  reportRunnerStarting(runner: JasmineRunner): void;
+  reportRunnerResults(runner: JasmineRunner): void;
+  reportSuiteResults(suite: JasmineSuite): void;
+  reportSpecStarting(spec: JasmineSpec): void;
+  reportSpecResults(spec: JasmineSpec): void;
+  log(str: string): void;
+}
+
+type JasmineMultiReporter = {
+  addReporter(reporter: JasmineReporter): void;
+} & JasmineReporter
+
+type JasmineRunner = {
+  execute(): void;
+  beforeEach(beforeEachFunction: JasmineSpecFunction): void;
+  afterEach(afterEachFunction: JasmineSpecFunction): void;
+  finishCallback(): void;
+  addSuite(suite: JasmineSuite): void;
+  add(block: JasmineBlock): void;
+  specs(): JasmineSpec[];
+  suites(): JasmineSuite[];
+  topLevelSuites(): JasmineSuite[];
+  results(): JasmineNestedResults;
+}
+
+type JasmineSpecFunction = {
+  (spec?: JasmineSpec): void;
+}
+
+type JasmineSuiteOrSpec = {
+  id: number;
+  env: JasmineEnv;
+  description: string;
+  queue: JasmineQueue;
+}
+
+type JasmineSpec = {
+  suite: JasmineSuite;
+
+  afterCallbacks: JasmineSpecFunction[];
+  spies_: JasmineSpy[];
+
+  results_: JasmineNestedResults;
+  matchersClass: JasmineMatchers;
+
+  getFullName(): string;
+  results(): JasmineNestedResults;
+  log(arguments: any): any;
+  runs(func: JasmineSpecFunction): JasmineSpec;
+  addToQueue(block: JasmineBlock): void;
+  addMatcherResult(result: JasmineResult): void;
+  expect(actual: any): any;
+  waits(timeout: number): JasmineSpec;
+  waitsFor(latchFunction: JasmineSpecFunction, timeoutMessage?: string, timeout?: number): JasmineSpec;
+  fail(e?: any): void;
+  getMatchersClass_(): JasmineMatchers;
+  addMatchers(matchersPrototype: any): void;
+  finishCallback(): void;
+  finish(onComplete?: () => void): void;
+  after(doAfter: JasmineSpecFunction): void;
+  execute(onComplete?: () => void): any;
+  addBeforesAndAftersToQueue(): void;
+  explodes(): void;
+  spyOn(obj: any, methodName: string, ignoreMethodDoesntExist: boolean): JasmineSpy;
+  removeAllSpies(): void;
+} & JasmineSuiteOrSpec
+
+type JasmineXSpec = {
+  id: number;
+  runs(): void;
+}
+
+type JasmineSuite = {
+  parentSuite: JasmineSuite;
+
+  getFullName(): string;
+  finish(onComplete?: () => void): void;
+  beforeEach(beforeEachFunction: JasmineSpecFunction): void;
+  afterEach(afterEachFunction: JasmineSpecFunction): void;
+  results(): JasmineNestedResults;
+  add(suiteOrSpec: JasmineSuiteOrSpec): void;
+  specs(): JasmineSpec[];
+  suites(): JasmineSuite[];
+  children(): any[];
+  execute(onComplete?: () => void): void;
+} & JasmineSuiteOrSpec
+
+type JasmineXSuite = {
+  execute(): void;
+}
+
+type JasmineSpy = {
+  (...params: any[]): any;
+
+  identity: string;
+  calls: any[];
+  mostRecentCall: { args: any[]; };
+  argsForCall: any[];
+  wasCalled: boolean;
+  callCount: number;
+
+  andReturn(value: any): JasmineSpy;
+  andCallThrough(): JasmineSpy;
+  andCallFake(fakeFunc: Function): JasmineSpy;
+}
+
+type JasmineUtil = {
+  inherit(childClass: Function, parentClass: Function): any;
+  formatException(e: any): any;
+  htmlEscape(str: string): string;
+  argsToArray(args: any): any;
+  extend(destination: any, source: any): any;
+}
+
+type JasmineJsApiReporter = {
+
+  started: boolean;
+  finished: boolean;
+  result: any;
+  messages: any;
+
+
+  suites(): JasmineSuite[];
+  summarize_(suiteOrSpec: JasmineSuiteOrSpec): any;
+  results(): any;
+  resultsForSpec(specId: any): any;
+  log(str: any): any;
+  resultsForSpecs(specIds: any): any;
+  summarizeResult_(result: any): any;
+} & JasmineReporter

--- a/lib/.eslintrc.json
+++ b/lib/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "atom": true
+  }
+}

--- a/lib/atom-ide-provider.js
+++ b/lib/atom-ide-provider.js
@@ -1,0 +1,61 @@
+/* @flow */
+
+// eslint-disable-next-line import/no-unresolved
+import type { BusySignalOptions, BusyMessage } from "atom-ide/busy-signal";
+import type Provider from "./provider";
+
+export class AtomIdeProvider {
+  createProvider: () => Provider;
+  messages: Set<BusyMessage> = new Set();
+
+  constructor(createProvider: () => Provider) {
+    this.createProvider = createProvider;
+  }
+
+  async reportBusyWhile<T>(
+    title: string,
+    f: () => Promise<T>,
+    options?: BusySignalOptions
+  ): Promise<T> {
+    const busyMessage = this.reportBusy(title, options);
+    try {
+      return await f();
+    } finally {
+      busyMessage.dispose();
+    }
+  }
+
+  reportBusy(title: string, options?: BusySignalOptions): BusyMessage {
+    const provider = this.createProvider();
+
+    let providerOptions = null;
+    if (options) {
+      providerOptions = {
+        onlyForFile: options.onlyForFile,
+        onDidClick: options.onDidClick
+      };
+    }
+
+    provider.add(title, providerOptions);
+
+    const busyMessage = {
+      setTitle: (newTitle: string) => {
+        provider.changeTitle(newTitle, title);
+      },
+      dispose: () => {
+        provider.dispose();
+        this.messages.delete(busyMessage);
+      }
+    };
+    this.messages.add(busyMessage);
+
+    return busyMessage;
+  }
+
+  dispose(): void {
+    this.messages.forEach(msg => {
+      msg.dispose();
+    });
+    this.messages.clear();
+  }
+}

--- a/lib/atom-ide-provider.js
+++ b/lib/atom-ide-provider.js
@@ -28,15 +28,11 @@ export class AtomIdeProvider {
   reportBusy(title: string, options?: BusySignalOptions): BusyMessage {
     const provider = this.createProvider();
 
-    let providerOptions = null;
     if (options) {
-      providerOptions = {
-        onlyForFile: options.onlyForFile,
-        onDidClick: options.onDidClick
-      };
+      // TODO: options not implemented yet
     }
 
-    provider.add(title, providerOptions);
+    provider.add(title);
 
     const busyMessage = {
       setTitle: (newTitle: string) => {

--- a/lib/element.js
+++ b/lib/element.js
@@ -1,54 +1,70 @@
 /* @flow */
 
-import escape from "escape-html";
 // eslint-disable-next-line import/no-unresolved
 import type { Disposable } from "atom";
+import type { SignalInternal } from "./types";
 
 const MESSAGE_IDLE = "Idle";
+
+function elementWithText(text, tag = "div") {
+  const el = document.createElement(tag);
+  el.textContent = text;
+  return el;
+}
 
 export class SignalElement extends HTMLElement {
   tooltip: Disposable;
   activatedLast: ?number;
-  deactivateTimer: ?number;
+  deactivateTimer: ?TimeoutID;
 
   createdCallback() {
     this.update([], []);
     this.classList.add("inline-block");
   }
   update(
-    titles: Array<string>,
+    titles: Array<SignalInternal>,
     history: Array<{ title: string, duration: string }>
   ) {
     this.setBusy(!!titles.length);
-    const tooltipMessage = [];
+
+    const el = document.createElement("div");
+    el.style.textAlign = "left";
+
     if (history.length) {
-      tooltipMessage.push(
-        "<strong>History:</strong>",
-        history
-          .map(function(item) {
-            return `${escape(item.title)} (${item.duration})`;
-          })
-          .join("<br>")
+      el.append(
+        elementWithText("History:", "strong"),
+        ...history.map(item =>
+          elementWithText(`${item.title} (${item.duration})`)
+        )
       );
     }
     if (titles.length) {
-      tooltipMessage.push(
-        "<strong>Current:</strong>",
-        titles.map(escape).join("<br>")
+      el.append(
+        elementWithText("Current:", "strong"),
+        ...titles.map(item => {
+          const e = elementWithText(item.title);
+          if (item.options) {
+            e.onclick = item.options.onDidClick;
+          }
+          return e;
+        })
       );
     }
-    if (tooltipMessage.length) {
-      this.setTooltip(tooltipMessage.join("<br>"));
-    } else {
-      this.setTooltip(MESSAGE_IDLE);
+
+    if (!el.childElementCount) {
+      el.textContent = MESSAGE_IDLE;
     }
+
+    this.setTooltip(el);
   }
   setBusy(busy: boolean) {
     if (busy) {
       this.classList.add("busy");
       this.classList.remove("idle");
       this.activatedLast = Date.now();
-      clearTimeout(this.deactivateTimer);
+      if (this.deactivateTimer) {
+        clearTimeout(this.deactivateTimer);
+      }
     } else {
       // The logic below makes sure that busy signal is shown for at least 1 second
       const timeNow = Date.now();
@@ -65,13 +81,11 @@ export class SignalElement extends HTMLElement {
       }
     }
   }
-  setTooltip(title: string) {
+  setTooltip(item: HTMLElement) {
     if (this.tooltip) {
       this.tooltip.dispose();
     }
-    this.tooltip = atom.tooltips.add(this, {
-      title: `<div style="text-align: left;">${title}</div>`
-    });
+    this.tooltip = atom.tooltips.add(this, { item });
   }
   dispose() {
     this.tooltip.dispose();

--- a/lib/element.js
+++ b/lib/element.js
@@ -1,9 +1,10 @@
 /* @flow */
 
-import escape from 'escape-html'
-import type { Disposable } from 'atom'
+import escape from "escape-html";
+// eslint-disable-next-line import/no-unresolved
+import type { Disposable } from "atom";
 
-const MESSAGE_IDLE = 'Idle'
+const MESSAGE_IDLE = "Idle";
 
 export class SignalElement extends HTMLElement {
   tooltip: Disposable;
@@ -11,60 +12,74 @@ export class SignalElement extends HTMLElement {
   deactivateTimer: ?number;
 
   createdCallback() {
-    this.update([], [])
-    this.classList.add('inline-block')
+    this.update([], []);
+    this.classList.add("inline-block");
   }
-  update(titles: Array<string>, history: Array<{ title: string, duration: string }>) {
-    this.setBusy(!!titles.length)
-    const tooltipMessage = []
+  update(
+    titles: Array<string>,
+    history: Array<{ title: string, duration: string }>
+  ) {
+    this.setBusy(!!titles.length);
+    const tooltipMessage = [];
     if (history.length) {
-      tooltipMessage.push('<strong>History:</strong>', history.map(function(item) {
-        return `${escape(item.title)} (${item.duration})`
-      }).join('<br>'))
+      tooltipMessage.push(
+        "<strong>History:</strong>",
+        history
+          .map(function(item) {
+            return `${escape(item.title)} (${item.duration})`;
+          })
+          .join("<br>")
+      );
     }
     if (titles.length) {
-      tooltipMessage.push('<strong>Current:</strong>', titles.map(escape).join('<br>'))
+      tooltipMessage.push(
+        "<strong>Current:</strong>",
+        titles.map(escape).join("<br>")
+      );
     }
     if (tooltipMessage.length) {
-      this.setTooltip(tooltipMessage.join('<br>'))
+      this.setTooltip(tooltipMessage.join("<br>"));
     } else {
-      this.setTooltip(MESSAGE_IDLE)
+      this.setTooltip(MESSAGE_IDLE);
     }
   }
   setBusy(busy: boolean) {
     if (busy) {
-      this.classList.add('busy')
-      this.classList.remove('idle')
-      this.activatedLast = Date.now()
-      clearTimeout(this.deactivateTimer)
+      this.classList.add("busy");
+      this.classList.remove("idle");
+      this.activatedLast = Date.now();
+      clearTimeout(this.deactivateTimer);
     } else {
       // The logic below makes sure that busy signal is shown for at least 1 second
-      const timeNow = Date.now()
-      const timeThen = this.activatedLast || 0
-      const timeDifference = timeNow - timeThen
+      const timeNow = Date.now();
+      const timeThen = this.activatedLast || 0;
+      const timeDifference = timeNow - timeThen;
       if (timeDifference < 1000) {
-        this.deactivateTimer = setTimeout(() => this.setBusy(false), timeDifference + 100)
+        this.deactivateTimer = setTimeout(
+          () => this.setBusy(false),
+          timeDifference + 100
+        );
       } else {
-        this.classList.add('idle')
-        this.classList.remove('busy')
+        this.classList.add("idle");
+        this.classList.remove("busy");
       }
     }
   }
   setTooltip(title: string) {
     if (this.tooltip) {
-      this.tooltip.dispose()
+      this.tooltip.dispose();
     }
     this.tooltip = atom.tooltips.add(this, {
-      title: `<div style="text-align: left;">${title}</div>`,
-    })
+      title: `<div style="text-align: left;">${title}</div>`
+    });
   }
   dispose() {
-    this.tooltip.dispose()
+    this.tooltip.dispose();
   }
 }
 
-const element = document.registerElement('busy-signal', {
-  prototype: SignalElement.prototype,
-})
+const element = document.registerElement("busy-signal", {
+  prototype: SignalElement.prototype
+});
 
-export default element
+export default element;

--- a/lib/element.js
+++ b/lib/element.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-// eslint-disable-next-line import/no-unresolved
-import type { Disposable } from "atom";
 import type { SignalInternal } from "./types";
 
 const MESSAGE_IDLE = "Idle";
@@ -13,7 +11,7 @@ function elementWithText(text, tag = "div") {
 }
 
 export class SignalElement extends HTMLElement {
-  tooltip: Disposable;
+  tooltip: ?IDisposable;
   activatedLast: ?number;
   deactivateTimer: ?TimeoutID;
 
@@ -88,7 +86,9 @@ export class SignalElement extends HTMLElement {
     this.tooltip = atom.tooltips.add(this, { item });
   }
   dispose() {
-    this.tooltip.dispose();
+    if (this.tooltip) {
+      this.tooltip.dispose();
+    }
   }
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,5 @@
 /* @flow */
 
 export function generateRandom(): string {
-  return Math.random().toString()
+  return Math.random().toString();
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,19 +1,19 @@
 /* @flow */
 
-import BusySignal from './main'
-import type SignalRegistry from './registry'
+import BusySignal from "./main";
+import type SignalRegistry from "./registry";
 
 module.exports = {
   activate() {
-    this.instance = new BusySignal()
+    this.instance = new BusySignal();
   },
   consumeStatusBar(statusBar: Object) {
-    this.instance.attach(statusBar)
+    this.instance.attach(statusBar);
   },
   providerRegistry(): SignalRegistry {
-    return this.instance.registry
+    return this.instance.registry;
   },
   deactivate() {
-    this.instance.dispose()
-  },
-}
+    this.instance.dispose();
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,9 @@
 /* @flow */
 
+import type {
+  BusySignalService,
+  BusySignalOptions
+} from "atom-ide/busy-signal"; // eslint-disable-line import/no-unresolved
 import BusySignal from "./main";
 import type SignalRegistry from "./registry";
 
@@ -12,6 +16,26 @@ module.exports = {
   },
   providerRegistry(): SignalRegistry {
     return this.instance.registry;
+  },
+  provideBusySignal(): BusySignalService {
+    const provider: BusySignalService = this.instance.atomIdeProvider;
+    return {
+      reportBusyWhile<T>(
+        title: string,
+        f: () => Promise<T>,
+        options?: BusySignalOptions
+      ) {
+        return provider.reportBusyWhile(title, f, options);
+      },
+
+      reportBusy(title: string, options?: BusySignalOptions) {
+        return provider.reportBusy(title, options);
+      },
+
+      dispose() {
+        // nop
+      }
+    };
   },
   deactivate() {
     this.instance.dispose();

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,9 +1,10 @@
 /* @flow */
 
-import { CompositeDisposable } from 'atom'
-import disposify from 'disposify'
-import Element from './element'
-import Registry from './registry'
+// eslint-disable-next-line import/no-unresolved
+import { CompositeDisposable } from "atom";
+import disposify from "disposify";
+import Element from "./element";
+import Registry from "./registry";
 
 export default class BusySignal {
   element: Element;
@@ -11,24 +12,31 @@ export default class BusySignal {
   subscriptions: CompositeDisposable;
 
   constructor() {
-    this.element = new Element()
-    this.registry = new Registry()
-    this.subscriptions = new CompositeDisposable()
+    this.element = new Element();
+    this.registry = new Registry();
+    this.subscriptions = new CompositeDisposable();
 
-    this.subscriptions.add(this.element)
-    this.subscriptions.add(this.registry)
+    this.subscriptions.add(this.element);
+    this.subscriptions.add(this.registry);
 
     this.registry.onDidUpdate(() => {
-      this.element.update(this.registry.getTilesActive(), this.registry.getTilesOld())
-    })
+      this.element.update(
+        this.registry.getTilesActive(),
+        this.registry.getTilesOld()
+      );
+    });
   }
   attach(statusBar: Object) {
-    this.subscriptions.add(disposify(statusBar.addRightTile({
-      item: this.element,
-      priority: 500,
-    })))
+    this.subscriptions.add(
+      disposify(
+        statusBar.addRightTile({
+          item: this.element,
+          priority: 500
+        })
+      )
+    );
   }
   dispose() {
-    this.subscriptions.dispose()
+    this.subscriptions.dispose();
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,15 +5,18 @@ import { CompositeDisposable } from "atom";
 import disposify from "disposify";
 import Element from "./element";
 import Registry from "./registry";
+import { AtomIdeProvider } from "./atom-ide-provider";
 
 export default class BusySignal {
   element: Element;
   registry: Registry;
+  atomIdeProvider: AtomIdeProvider;
   subscriptions: CompositeDisposable;
 
   constructor() {
     this.element = new Element();
     this.registry = new Registry();
+    this.atomIdeProvider = new AtomIdeProvider(() => this.registry.create());
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(this.element);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -2,9 +2,8 @@
 
 // eslint-disable-next-line import/no-unresolved
 import { CompositeDisposable, Emitter } from "atom";
-// eslint-disable-next-line import/no-unresolved
-import type { Disposable } from "atom";
 import { generateRandom } from "./helpers";
+import type { SignalOptions } from "./types";
 
 export default class Provider {
   id: string;
@@ -18,30 +17,44 @@ export default class Provider {
 
     this.subscriptions.add(this.emitter);
   }
+
   // Public
-  add(title: string) {
-    this.emitter.emit("did-add", title);
+  add(title: string, options?: ?SignalOptions) {
+    this.emitter.emit("did-add", { title, options });
   }
   // Public
   remove(title: string) {
     this.emitter.emit("did-remove", title);
   }
   // Public
+  changeTitle(title: string, oldTitle: string) {
+    this.emitter.emit("did-change-title", { title, oldTitle });
+  }
+  // Public
   clear() {
     this.emitter.emit("did-clear");
   }
-  onDidAdd(callback: (title: string) => any): Disposable {
+
+  onDidAdd(
+    callback: (add: { title: string, options: ?SignalOptions }) => any
+  ): IDisposable {
     return this.emitter.on("did-add", callback);
   }
-  onDidRemove(callback: (title: string) => any): Disposable {
+  onDidRemove(callback: (title: string) => any): IDisposable {
     return this.emitter.on("did-remove", callback);
   }
-  onDidClear(callback: () => any): Disposable {
+  onDidChangeTitle(
+    callback: (change: { title: string, oldTitle: string }) => any
+  ): IDisposable {
+    return this.emitter.on("did-change-title", callback);
+  }
+  onDidClear(callback: () => any): IDisposable {
     return this.emitter.on("did-clear", callback);
   }
-  onDidDispose(callback: Function): Disposable {
+  onDidDispose(callback: Function): IDisposable {
     return this.emitter.on("did-dispose", callback);
   }
+
   dispose() {
     this.emitter.emit("did-dispose");
     this.subscriptions.dispose();

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,8 +1,10 @@
 /* @flow */
 
-import { CompositeDisposable, Emitter } from 'atom'
-import type { Disposable } from 'atom'
-import { generateRandom } from './helpers'
+// eslint-disable-next-line import/no-unresolved
+import { CompositeDisposable, Emitter } from "atom";
+// eslint-disable-next-line import/no-unresolved
+import type { Disposable } from "atom";
+import { generateRandom } from "./helpers";
 
 export default class Provider {
   id: string;
@@ -10,38 +12,38 @@ export default class Provider {
   subscriptions: CompositeDisposable;
 
   constructor() {
-    this.id = generateRandom()
-    this.emitter = new Emitter()
-    this.subscriptions = new CompositeDisposable()
+    this.id = generateRandom();
+    this.emitter = new Emitter();
+    this.subscriptions = new CompositeDisposable();
 
-    this.subscriptions.add(this.emitter)
+    this.subscriptions.add(this.emitter);
   }
   // Public
   add(title: string) {
-    this.emitter.emit('did-add', title)
+    this.emitter.emit("did-add", title);
   }
   // Public
   remove(title: string) {
-    this.emitter.emit('did-remove', title)
+    this.emitter.emit("did-remove", title);
   }
   // Public
   clear() {
-    this.emitter.emit('did-clear')
+    this.emitter.emit("did-clear");
   }
-  onDidAdd(callback: ((title: string) => any)): Disposable {
-    return this.emitter.on('did-add', callback)
+  onDidAdd(callback: (title: string) => any): Disposable {
+    return this.emitter.on("did-add", callback);
   }
-  onDidRemove(callback: ((title: string) => any)): Disposable {
-    return this.emitter.on('did-remove', callback)
+  onDidRemove(callback: (title: string) => any): Disposable {
+    return this.emitter.on("did-remove", callback);
   }
-  onDidClear(callback: (() => any)): Disposable {
-    return this.emitter.on('did-clear', callback)
+  onDidClear(callback: () => any): Disposable {
+    return this.emitter.on("did-clear", callback);
   }
   onDidDispose(callback: Function): Disposable {
-    return this.emitter.on('did-dispose', callback)
+    return this.emitter.on("did-dispose", callback);
   }
   dispose() {
-    this.emitter.emit('did-dispose')
-    this.subscriptions.dispose()
+    this.emitter.emit("did-dispose");
+    this.subscriptions.dispose();
   }
 }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -3,11 +3,9 @@
 import ms from "ms";
 // eslint-disable-next-line import/no-unresolved
 import { CompositeDisposable, Emitter } from "atom";
-// eslint-disable-next-line import/no-unresolved
-import type { Disposable } from "atom";
 
 import Provider from "./provider";
-import type { SignalInternal } from "./types";
+import type { SignalInternal, SignalOptions } from "./types";
 
 export default class Registry {
   emitter: Emitter;
@@ -29,11 +27,14 @@ export default class Registry {
   // Public method
   create(): Provider {
     const provider = new Provider();
-    provider.onDidAdd(status => {
-      this.statusAdd(provider, status);
+    provider.onDidAdd(({ title, options }) => {
+      this.statusAdd(provider, title, options);
     });
     provider.onDidRemove(title => {
       this.statusRemove(provider, title);
+    });
+    provider.onDidChangeTitle(({ title, oldTitle }) => {
+      this.statusChangeTitle(provider, title, oldTitle);
     });
     provider.onDidClear(() => {
       this.statusClear(provider);
@@ -45,7 +46,7 @@ export default class Registry {
     this.providers.add(provider);
     return provider;
   }
-  statusAdd(provider: Provider, title: string): void {
+  statusAdd(provider: Provider, title: string, options?: ?SignalOptions): void {
     const key = `${provider.id}::${title}`;
     if (this.statuses.has(key)) {
       // This will help catch bugs in providers
@@ -57,7 +58,8 @@ export default class Registry {
       title,
       provider,
       timeStarted: Date.now(),
-      timeStopped: null
+      timeStopped: null,
+      options
     };
     this.statuses.set(entry.key, entry);
     this.emitter.emit("did-update");
@@ -70,6 +72,21 @@ export default class Registry {
       this.statuses.delete(key);
       this.emitter.emit("did-update");
     }
+  }
+  statusChangeTitle(provider: Provider, title: string, oldTitle: string): void {
+    const oldKey = `${provider.id}::${oldTitle}`;
+    const entry = this.statuses.get(oldKey);
+    if (!entry) {
+      return;
+    }
+
+    this.statuses.delete(oldKey);
+
+    entry.title = title;
+    entry.key = `${provider.id}::${title}`;
+
+    this.statuses.set(entry.key, entry);
+    this.emitter.emit("did-update");
   }
   statusClear(provider: Provider): void {
     let triggerUpdate = false;
@@ -96,10 +113,10 @@ export default class Registry {
     this.statusHistory.push(status);
     this.statusHistory = this.statusHistory.slice(-10);
   }
-  getTilesActive(): Array<string> {
-    return Array.from(this.statuses.values())
-      .sort((a, b) => b.timeStarted - a.timeStarted)
-      .map(a => a.title);
+  getTilesActive(): Array<SignalInternal> {
+    return Array.from(this.statuses.values()).sort(
+      (a, b) => b.timeStarted - a.timeStarted
+    );
   }
   getTilesOld(): Array<{ title: string, duration: string }> {
     const oldTiles = [];
@@ -114,7 +131,7 @@ export default class Registry {
 
     return oldTiles;
   }
-  onDidUpdate(callback: Function): Disposable {
+  onDidUpdate(callback: Function): IDisposable {
     return this.emitter.on("did-update", callback);
   }
   dispose() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,53 +1,55 @@
 /* @flow */
 
-import ms from 'ms'
-import { CompositeDisposable, Emitter } from 'atom'
-import type { Disposable } from 'atom'
+import ms from "ms";
+// eslint-disable-next-line import/no-unresolved
+import { CompositeDisposable, Emitter } from "atom";
+// eslint-disable-next-line import/no-unresolved
+import type { Disposable } from "atom";
 
-import Provider from './provider'
-import type { SignalInternal } from './types'
+import Provider from "./provider";
+import type { SignalInternal } from "./types";
 
 export default class Registry {
-  emitter: Emitter
-  providers: Set<Provider>
-  subscriptions: CompositeDisposable
+  emitter: Emitter;
+  providers: Set<Provider>;
+  subscriptions: CompositeDisposable;
 
-  statuses: Map<string, SignalInternal>
-  statusHistory: Array<SignalInternal>
+  statuses: Map<string, SignalInternal>;
+  statusHistory: Array<SignalInternal>;
 
   constructor() {
-    this.emitter = new Emitter()
-    this.providers = new Set()
-    this.subscriptions = new CompositeDisposable()
-    this.subscriptions.add(this.emitter)
+    this.emitter = new Emitter();
+    this.providers = new Set();
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(this.emitter);
 
-    this.statuses = new Map()
-    this.statusHistory = []
+    this.statuses = new Map();
+    this.statusHistory = [];
   }
   // Public method
   create(): Provider {
-    const provider = new Provider()
-    provider.onDidAdd((status) => {
-      this.statusAdd(provider, status)
-    })
-    provider.onDidRemove((title) => {
-      this.statusRemove(provider, title)
-    })
+    const provider = new Provider();
+    provider.onDidAdd(status => {
+      this.statusAdd(provider, status);
+    });
+    provider.onDidRemove(title => {
+      this.statusRemove(provider, title);
+    });
     provider.onDidClear(() => {
-      this.statusClear(provider)
-    })
+      this.statusClear(provider);
+    });
     provider.onDidDispose(() => {
-      this.statusClear(provider)
-      this.providers.delete(provider)
-    })
-    this.providers.add(provider)
-    return provider
+      this.statusClear(provider);
+      this.providers.delete(provider);
+    });
+    this.providers.add(provider);
+    return provider;
   }
   statusAdd(provider: Provider, title: string): void {
-    const key = `${provider.id}::${title}`
+    const key = `${provider.id}::${title}`;
     if (this.statuses.has(key)) {
       // This will help catch bugs in providers
-      throw new Error(`Status '${title}' is already set`)
+      throw new Error(`Status '${title}' is already set`);
     }
 
     const entry = {
@@ -55,68 +57,70 @@ export default class Registry {
       title,
       provider,
       timeStarted: Date.now(),
-      timeStopped: null,
-    }
-    this.statuses.set(entry.key, entry)
-    this.emitter.emit('did-update')
+      timeStopped: null
+    };
+    this.statuses.set(entry.key, entry);
+    this.emitter.emit("did-update");
   }
   statusRemove(provider: Provider, title: string): void {
-    const key = `${provider.id}::${title}`
-    const value = this.statuses.get(key)
+    const key = `${provider.id}::${title}`;
+    const value = this.statuses.get(key);
     if (value) {
-      this.pushIntoHistory(value)
-      this.statuses.delete(key)
-      this.emitter.emit('did-update')
+      this.pushIntoHistory(value);
+      this.statuses.delete(key);
+      this.emitter.emit("did-update");
     }
   }
   statusClear(provider: Provider): void {
-    let triggerUpdate = false
-    this.statuses.forEach((value) => {
+    let triggerUpdate = false;
+    this.statuses.forEach(value => {
       if (value.provider === provider) {
-        triggerUpdate = true
-        this.pushIntoHistory(value)
-        this.statuses.delete(value.key)
+        triggerUpdate = true;
+        this.pushIntoHistory(value);
+        this.statuses.delete(value.key);
       }
-    })
+    });
     if (triggerUpdate) {
-      this.emitter.emit('did-update')
+      this.emitter.emit("did-update");
     }
   }
   pushIntoHistory(status: SignalInternal): void {
-    status.timeStopped = Date.now()
-    let i = this.statusHistory.length
+    status.timeStopped = Date.now();
+    let i = this.statusHistory.length;
     while (i--) {
       if (this.statusHistory[i].key === status.key) {
-        this.statusHistory.splice(i, 1)
-        break
+        this.statusHistory.splice(i, 1);
+        break;
       }
     }
-    this.statusHistory.push(status)
-    this.statusHistory = this.statusHistory.slice(-10)
+    this.statusHistory.push(status);
+    this.statusHistory = this.statusHistory.slice(-10);
   }
   getTilesActive(): Array<string> {
-    return Array.from(this.statuses.values()).sort((a, b) => b.timeStarted - a.timeStarted).map(a => a.title)
+    return Array.from(this.statuses.values())
+      .sort((a, b) => b.timeStarted - a.timeStarted)
+      .map(a => a.title);
   }
   getTilesOld(): Array<{ title: string, duration: string }> {
-    const oldTiles = []
+    const oldTiles = [];
 
-    this.statusHistory.forEach((entry) => {
-      if (this.statuses.has(entry.key)) return
+    this.statusHistory.forEach(entry => {
+      if (this.statuses.has(entry.key)) return;
       oldTiles.push({
         title: entry.title,
-        duration: ms((entry.timeStopped || 0) - entry.timeStarted),
-      })
-    })
+        duration: ms((entry.timeStopped || 0) - entry.timeStarted)
+      });
+    });
 
-    return oldTiles
+    return oldTiles;
   }
   onDidUpdate(callback: Function): Disposable {
-    return this.emitter.on('did-update', callback)
+    return this.emitter.on("did-update", callback);
   }
   dispose() {
-    this.subscriptions.dispose()
+    this.subscriptions.dispose();
     for (const provider of this.providers) {
-      provider.dispose()
+      provider.dispose();
     }
   }
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import type Provider from './provider'
+import type Provider from "./provider";
 
 export type SignalInternal = {
   key: string,
   title: string,
   provider: Provider,
   timeStarted: number,
-  timeStopped: ?number,
-}
+  timeStopped: ?number
+};

--- a/lib/types.js
+++ b/lib/types.js
@@ -2,10 +2,16 @@
 
 import type Provider from "./provider";
 
+export type SignalOptions = {
+  onlyForFile?: string,
+  onDidClick?: () => void
+};
+
 export type SignalInternal = {
   key: string,
   title: string,
   provider: Provider,
   timeStarted: number,
-  timeStopped: ?number
+  timeStopped: ?number,
+  options?: ?SignalOptions
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -432,11 +432,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,111 +4,186 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
+      "integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.2.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+      "integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/types": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+      "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
-    "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
+    "ajv": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "version": "3.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.3.0.tgz",
-      "integrity": "sha1-y4qZhOKGJxHIPICt5bj1yg3itGc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "dev": true,
       "requires": {
-        "ast-types-flow": "0.0.7"
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
       }
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "array.prototype.find": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.0"
-      }
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -116,82 +191,34 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "ast-types-flow": "0.0.7"
       }
     },
     "babel-eslint": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
       }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0",
-        "regenerator-runtime": "0.11.0"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.8",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -200,12 +227,12 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -221,7 +248,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -231,17 +258,21 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -250,30 +281,39 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
     "concat-map": {
@@ -282,42 +322,23 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
-    "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.27"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "damerau-levenshtein": {
@@ -327,12 +348,20 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "deep-is": {
@@ -342,28 +371,12 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "object-keys": "^1.0.12"
       }
     },
     "disposify": {
@@ -372,13 +385,12 @@
       "integrity": "sha1-MwZvYxRiuIoIMpTRSOHwSlAsFec="
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2"
       }
     },
     "emoji-regex": {
@@ -388,106 +400,36 @@
       "dev": true
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
-      "integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.27",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
-      "integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.27",
-        "es6-symbol": "3.1.1"
-      }
-    },
-    "es6-map": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.27",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
-    },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.27",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.27"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.27",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-html": {
@@ -501,180 +443,284 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escope": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
-    },
     "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.11.1.tgz",
+      "integrity": "sha512-gOKhM8JwlFOc2acbOrkYR05NW8M6DCMSvfcJiBB5NDxRE1gv8kbvxKaC9u69e6ZGEMWXcswA/7eKR229cEIpvg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.8",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.0",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.3",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
       }
     },
     "eslint-config-airbnb": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-14.1.0.tgz",
-      "integrity": "sha1-NV0pAEC7+OAL+LSxn0twy+fCMX8=",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
+      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "11.3.1"
+        "eslint-config-airbnb-base": "^13.1.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz",
-      "integrity": "sha512-BXVH7PV5yiLjnkv49iOLJ8dWp+ljZf310ytQpqwrunFADiEbWRyN0tPGDU36FgEbdLvhJDWcJOngYDzPF4shDw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
+      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "0.1.1"
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz",
+      "integrity": "sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-steelbrain": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-steelbrain/-/eslint-config-steelbrain-3.0.1.tgz",
-      "integrity": "sha1-DlctYvipK9vvEzIF4gPT5fV1MTg=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-steelbrain/-/eslint-config-steelbrain-6.0.0.tgz",
+      "integrity": "sha512-ANauzauToKVrxVsEtaDvPbhbvs796SfVN+kyO5moXouodDc4xV5QGc/w7T+NUmFBaK0mykbUfV97Krl5g743tg==",
       "dev": true,
       "requires": {
-        "babel-eslint": "7.2.3",
-        "eslint": "3.19.0",
-        "eslint-config-airbnb": "14.1.0",
-        "eslint-plugin-import": "2.7.0",
-        "eslint-plugin-jsx-a11y": "4.0.0",
-        "eslint-plugin-react": "6.10.3"
+        "babel-eslint": "^9.0.0",
+        "eslint": "^5.6.0",
+        "eslint-config-airbnb": "^17.1.0",
+        "eslint-config-prettier": "^3.0.1",
+        "eslint-plugin-flowtype": "^2.50.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-jsx-a11y": "^6.1.1",
+        "eslint-plugin-prettier": "^2.6.2",
+        "eslint-plugin-react": "^7.11.1",
+        "prettier": "^1.14.2"
+      },
+      "dependencies": {
+        "eslint-plugin-flowtype": {
+          "version": "2.50.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.3.tgz",
+          "integrity": "sha512-X+AoKVOr7Re0ko/yEXyM5SSZ0tazc6ffdIOocp2fFUlWoDt7DV0Bz99mngOkAFLOAWjqRA5jPwqUCbrx13XoxQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        }
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "resolve": "1.4.0"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "eslint-plugin-flowtype": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.0.tgz",
+      "integrity": "sha512-baJmzngM6UKbEkJ5OY3aGw2zjXBt5L2QKZvTsOlXX7yHKIjNRrlJx2ods8Rng6EdqPR9rVNIQNYHpTs0qfn2qA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
-      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.8",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz",
-      "integrity": "sha1-d5uw/nsI2lZKQiYkkR3hAGHgSO4=",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
+      "integrity": "sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==",
       "dev": true,
       "requires": {
-        "aria-query": "0.3.0",
-        "ast-types-flow": "0.0.7",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "1.4.1",
-        "object-assign": "4.1.1"
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.1",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^6.5.1",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+      "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
       }
     },
     "eslint-plugin-react": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.0.tgz",
+      "integrity": "sha512-OrmXBWGrZ8gvYWO0W4oiLtASxFWVfe2blgy5pvB57YRwylhghUQL5y5w70fysP/CRTt/XJ+FLv/KXhZxbsQwiw==",
       "dev": true,
       "requires": {
-        "array.prototype.find": "2.0.4",
-        "doctrine": "1.5.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.0.4"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
-        }
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.6.2",
+        "resolve": "^1.9.0"
       }
     },
     "eslint-restricted-globals": {
@@ -683,39 +729,61 @@
       "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
       "dev": true
     },
-    "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
-        "acorn-jsx": "3.0.1"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -730,20 +798,33 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.27"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -753,13 +834,12 @@
       "dev": true
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -768,8 +848,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "find-up": {
@@ -778,32 +858,26 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       }
     },
     "flow-bin": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.53.0.tgz",
-      "integrity": "sha1-94MOYJygKxLbQScRQhPMzHwHcbk=",
-      "dev": true
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "version": "0.89.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.89.0.tgz",
+      "integrity": "sha512-DkO4PsXYrl53V6G5+t5HbRMC5ajYUQej2LEGPUZ+j9okTb41Sn5j9vfxsCpXMEAslYnQoysHhYu4GUZsQX/DrQ==",
       "dev": true
     },
     "fs.realpath": {
@@ -813,94 +887,89 @@
       "dev": true
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
     },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "imurmurhash": {
@@ -915,8 +984,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -926,39 +995,41 @@
       "dev": true
     },
     "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
-      }
-    },
-    "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-      "dev": true
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "1.3.1"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -973,13 +1044,13 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-date-object": {
@@ -989,54 +1060,15 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
@@ -1045,23 +1077,17 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
-      }
-    },
-    "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -1069,54 +1095,66 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "jasmine-fix": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jasmine-fix/-/jasmine-fix-1.3.0.tgz",
-      "integrity": "sha512-jZkspT2/rAr4Ycf8Vs0UkxhFBk+qFkOYL30wEKJQTEGXsOtMpBsVPTWQwcWzMQv+V7ZZhg2+fCm9ndXnTIqEfw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jasmine-fix/-/jasmine-fix-1.3.1.tgz",
+      "integrity": "sha512-jxfPMW5neQUrgEZR7FIXp1UAberYAHkpWTmdSfN/ulU+sC/yUsB827tRiwGUaUyw+1kNC5jqcINst0FF8tvVvg==",
+      "dev": true
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "jsx-ast-utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -1124,8 +1162,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1134,10 +1172,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -1146,8 +1184,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -1159,25 +1197,25 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1185,7 +1223,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1204,14 +1242,14 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "version": "0.0.7",
+      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "natural-compare": {
@@ -1220,23 +1258,23 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1245,20 +1283,45 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "object.assign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.0",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
       }
     },
     "once": {
@@ -1267,14 +1330,17 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "optionator": {
       "version": "0.8.2",
@@ -1282,25 +1348,28 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
-    "os-homedir": {
+    "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -1308,8 +1377,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
@@ -1317,7 +1392,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -1326,7 +1401,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -1341,10 +1416,16 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -1353,7 +1434,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pify": {
@@ -1374,7 +1455,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -1383,13 +1464,13 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -1398,16 +1479,32 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+    "prettier": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
       "dev": true
     },
     "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "read-pkg": {
@@ -1416,9 +1513,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -1427,8 +1524,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -1437,50 +1534,15 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
     },
-    "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.4.0"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "require-uncached": {
@@ -1489,17 +1551,17 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -1509,87 +1571,122 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "is-promise": "^2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.3",
-        "rechoir": "0.6.2"
+        "shebang-regex": "^1.0.0"
       }
     },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
     "sprintf-js": {
@@ -1598,33 +1695,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -1640,56 +1727,24 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
+      "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "2.0.0",
+        "string-width": "^2.1.1"
       }
     },
     "text-table": {
@@ -1704,16 +1759,31 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "type-check": {
@@ -1722,38 +1792,35 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "punycode": "^2.1.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -1774,14 +1841,8 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
   "dependencies": {
     "disposify": "^1.0.0",
     "escape-html": "^1.0.3",
-    "ms": "^2.0.0"
+    "ms": "^2.1.1"
   },
   "devDependencies": {
-    "eslint-config-steelbrain": "^3.0.1",
-    "flow-bin": "^0.75.0",
-    "jasmine-fix": "^1.0.1"
+    "eslint-config-steelbrain": "^6.0.0",
+    "eslint-plugin-flowtype": "^3.2.0",
+    "flow-bin": "^0.89.0",
+    "jasmine-fix": "^1.3.1"
   },
   "scripts": {
     "test": "apm test",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "disposify": "^1.0.0",
-    "escape-html": "^1.0.3",
     "ms": "^2.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
       "versions": {
         "1.0.0": "providerRegistry"
       }
+    },
+    "atom-ide-busy-signal": {
+      "versions": {
+        "0.1.0": "provideBusySignal"
+      }
     }
   },
   "dependencies": {

--- a/spec/atom-ide-provider-spec.js
+++ b/spec/atom-ide-provider-spec.js
@@ -1,0 +1,93 @@
+/* @flow */
+
+import { it, wait } from "jasmine-fix";
+import Registry from "../lib/registry";
+import { AtomIdeProvider } from "../lib/atom-ide-provider";
+import type { SignalInternal } from "../lib/types";
+
+describe("Atom IDE Provider", function() {
+  let registry;
+  let atomIdeProvider;
+
+  beforeEach(function() {
+    registry = new Registry();
+    atomIdeProvider = new AtomIdeProvider(() => registry.create());
+  });
+  afterEach(function() {
+    atomIdeProvider.dispose();
+    registry.dispose();
+  });
+
+  function validateTiles(
+    actual: Array<SignalInternal>,
+    expected: Array<string>
+  ) {
+    expect(actual.length).toBe(expected.length);
+
+    actual.forEach((entry, index) => {
+      expect(entry.title).toBe(expected[index]);
+    });
+  }
+  function validateOldTiles(
+    oldTitles: Array<{ title: string, duration: string }>,
+    titles: Array<string>,
+    checkDuration: boolean = true
+  ) {
+    expect(oldTitles.length).toBe(titles.length);
+
+    titles.forEach(function(title, index) {
+      expect(oldTitles[index].title).toBe(title);
+      if (checkDuration) {
+        expect(
+          oldTitles[index].duration === "1ms" ||
+            oldTitles[index].duration === "0ms"
+        ).toBe(true);
+      }
+    });
+  }
+
+  describe("reportBusy", function() {
+    it("adds titles", function() {
+      atomIdeProvider.reportBusy("Hello");
+      validateTiles(registry.getTilesActive(), ["Hello"]);
+    });
+    it("adds removed ones to history", async function() {
+      atomIdeProvider.reportBusy("Boy");
+      await wait(1);
+      const msg = atomIdeProvider.reportBusy("Hey");
+
+      validateTiles(registry.getTilesActive(), ["Hey", "Boy"]);
+      expect(registry.getTilesOld()).toEqual([]);
+
+      msg.dispose();
+      validateTiles(registry.getTilesActive(), ["Boy"]);
+      validateOldTiles(registry.getTilesOld(), ["Hey"], false);
+    });
+    it("can set a new title", function() {
+      const msg = atomIdeProvider.reportBusy("Hi");
+      validateTiles(registry.getTilesActive(), ["Hi"]);
+      msg.setTitle("Howdy");
+      validateTiles(registry.getTilesActive(), ["Howdy"]);
+      msg.dispose();
+      validateTiles(registry.getTilesActive(), []);
+      validateOldTiles(registry.getTilesOld(), ["Howdy"], false);
+    });
+  });
+  describe("reportBusyWhile", function() {
+    function waitWithValue(timeout, v) {
+      return new Promise(function(resolve) {
+        setTimeout(() => resolve(v), timeout);
+      });
+    }
+    it("adds titles", async function() {
+      const prom = atomIdeProvider.reportBusyWhile("Hello", () =>
+        waitWithValue(1, "Bazinga!")
+      );
+      validateTiles(registry.getTilesActive(), ["Hello"]);
+      const v = await prom;
+      expect(v).toBe("Bazinga!");
+      validateTiles(registry.getTilesActive(), []);
+      validateOldTiles(registry.getTilesOld(), ["Hello"], false);
+    });
+  });
+});

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -1,42 +1,50 @@
 /* @flow */
 
-import Element from '../lib/element'
+import Element from "../lib/element";
 
-describe('Element', function() {
-  let element
+describe("Element", function() {
+  let element;
 
   beforeEach(function() {
-    element = new Element()
-    spyOn(element, 'setTooltip').andCallThrough()
-    spyOn(element, 'setBusy').andCallThrough()
-  })
+    element = new Element();
+    spyOn(element, "setTooltip").andCallThrough();
+    spyOn(element, "setBusy").andCallThrough();
+  });
   afterEach(function() {
-    element.dispose()
-  })
+    element.dispose();
+  });
 
-  it('sets a title properly', function() {
-    element.update(['Hello'], [])
-    expect(element.setBusy).toHaveBeenCalledWith(true)
-    expect(element.setTooltip).toHaveBeenCalledWith('<strong>Current:</strong><br>Hello')
-  })
-  it('escapes the given texts', function() {
-    element.update(['<div>'], [])
-    expect(element.setBusy).toHaveBeenCalledWith(true)
-    expect(element.setTooltip).toHaveBeenCalledWith('<strong>Current:</strong><br>&lt;div&gt;')
-  })
-  it('shows idle message when nothing is provided', function() {
-    element.update([], [])
-    expect(element.setBusy).toHaveBeenCalledWith(false)
-    expect(element.setTooltip).toHaveBeenCalledWith('Idle')
-  })
-  it('shows only history when current is not present', function() {
-    element.update([], [{ title: 'Yo', duration: '1m' }])
-    expect(element.setBusy).toHaveBeenCalledWith(false)
-    expect(element.setTooltip).toHaveBeenCalledWith('<strong>History:</strong><br>Yo (1m)')
-  })
-  it('shows both history and current when both are present', function() {
-    element.update(['Hey'], [{ title: 'Yo', duration: '1m' }])
-    expect(element.setBusy).toHaveBeenCalledWith(true)
-    expect(element.setTooltip).toHaveBeenCalledWith('<strong>History:</strong><br>Yo (1m)<br><strong>Current:</strong><br>Hey')
-  })
-})
+  it("sets a title properly", function() {
+    element.update(["Hello"], []);
+    expect(element.setBusy).toHaveBeenCalledWith(true);
+    expect(element.setTooltip).toHaveBeenCalledWith(
+      "<strong>Current:</strong><br>Hello"
+    );
+  });
+  it("escapes the given texts", function() {
+    element.update(["<div>"], []);
+    expect(element.setBusy).toHaveBeenCalledWith(true);
+    expect(element.setTooltip).toHaveBeenCalledWith(
+      "<strong>Current:</strong><br>&lt;div&gt;"
+    );
+  });
+  it("shows idle message when nothing is provided", function() {
+    element.update([], []);
+    expect(element.setBusy).toHaveBeenCalledWith(false);
+    expect(element.setTooltip).toHaveBeenCalledWith("Idle");
+  });
+  it("shows only history when current is not present", function() {
+    element.update([], [{ title: "Yo", duration: "1m" }]);
+    expect(element.setBusy).toHaveBeenCalledWith(false);
+    expect(element.setTooltip).toHaveBeenCalledWith(
+      "<strong>History:</strong><br>Yo (1m)"
+    );
+  });
+  it("shows both history and current when both are present", function() {
+    element.update(["Hey"], [{ title: "Yo", duration: "1m" }]);
+    expect(element.setBusy).toHaveBeenCalledWith(true);
+    expect(element.setTooltip).toHaveBeenCalledWith(
+      "<strong>History:</strong><br>Yo (1m)<br><strong>Current:</strong><br>Hey"
+    );
+  });
+});

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -14,37 +14,36 @@ describe("Element", function() {
     element.dispose();
   });
 
+  function validateSetTooltip(call: number, html: string) {
+    expect(element.setTooltip.calls[call].args[0].innerHTML).toEqual(html);
+  }
+
   it("sets a title properly", function() {
-    element.update(["Hello"], []);
+    element.update([{ title: "Hello" }], []);
     expect(element.setBusy).toHaveBeenCalledWith(true);
-    expect(element.setTooltip).toHaveBeenCalledWith(
-      "<strong>Current:</strong><br>Hello"
-    );
+    validateSetTooltip(0, "<strong>Current:</strong><div>Hello</div>");
   });
   it("escapes the given texts", function() {
-    element.update(["<div>"], []);
+    element.update([{ title: "<div>" }], []);
     expect(element.setBusy).toHaveBeenCalledWith(true);
-    expect(element.setTooltip).toHaveBeenCalledWith(
-      "<strong>Current:</strong><br>&lt;div&gt;"
-    );
+    validateSetTooltip(0, "<strong>Current:</strong><div>&lt;div&gt;</div>");
   });
   it("shows idle message when nothing is provided", function() {
     element.update([], []);
     expect(element.setBusy).toHaveBeenCalledWith(false);
-    expect(element.setTooltip).toHaveBeenCalledWith("Idle");
+    validateSetTooltip(0, "Idle");
   });
   it("shows only history when current is not present", function() {
     element.update([], [{ title: "Yo", duration: "1m" }]);
     expect(element.setBusy).toHaveBeenCalledWith(false);
-    expect(element.setTooltip).toHaveBeenCalledWith(
-      "<strong>History:</strong><br>Yo (1m)"
-    );
+    validateSetTooltip(0, "<strong>History:</strong><div>Yo (1m)</div>");
   });
   it("shows both history and current when both are present", function() {
-    element.update(["Hey"], [{ title: "Yo", duration: "1m" }]);
+    element.update([{ title: "Hey" }], [{ title: "Yo", duration: "1m" }]);
     expect(element.setBusy).toHaveBeenCalledWith(true);
-    expect(element.setTooltip).toHaveBeenCalledWith(
-      "<strong>History:</strong><br>Yo (1m)<br><strong>Current:</strong><br>Hey"
+    validateSetTooltip(
+      0,
+      "<strong>History:</strong><div>Yo (1m)</div><strong>Current:</strong><div>Hey</div>"
     );
   });
 });

--- a/spec/provider-spec.js
+++ b/spec/provider-spec.js
@@ -17,11 +17,11 @@ describe("Provider", function() {
 
     provider.onDidAdd(function(title) {
       if (timesTriggered === 0) {
-        expect(title).toBe("First");
+        expect(title).toEqual({ title: "First", options: undefined });
       } else if (timesTriggered === 1) {
-        expect(title).toBe("Second");
+        expect(title).toEqual({ title: "Second", options: undefined });
       } else if (timesTriggered === 2) {
-        expect(title).toBe("Third");
+        expect(title).toEqual({ title: "Third", options: undefined });
       } else {
         expect(false).toBe(true);
       }

--- a/spec/provider-spec.js
+++ b/spec/provider-spec.js
@@ -1,96 +1,96 @@
 /* @flow */
 
-import Provider from '../lib/provider'
+import Provider from "../lib/provider";
 
-describe('Provider', function() {
-  let provider
+describe("Provider", function() {
+  let provider;
 
   beforeEach(function() {
-    provider = new Provider()
-  })
+    provider = new Provider();
+  });
   afterEach(function() {
-    provider.dispose()
-  })
+    provider.dispose();
+  });
 
-  it('emits add event properly', function() {
-    let timesTriggered = 0
+  it("emits add event properly", function() {
+    let timesTriggered = 0;
 
     provider.onDidAdd(function(title) {
       if (timesTriggered === 0) {
-        expect(title).toBe('First')
+        expect(title).toBe("First");
       } else if (timesTriggered === 1) {
-        expect(title).toBe('Second')
+        expect(title).toBe("Second");
       } else if (timesTriggered === 2) {
-        expect(title).toBe('Third')
+        expect(title).toBe("Third");
       } else {
-        expect(false).toBe(true)
+        expect(false).toBe(true);
       }
-      timesTriggered++
-    })
-    expect(timesTriggered).toBe(0)
-    provider.add('First')
-    expect(timesTriggered).toBe(1)
-    provider.add('Second')
-    expect(timesTriggered).toBe(2)
-    provider.add('Third')
-    expect(timesTriggered).toBe(3)
-  })
-  it('emits remove event properly', function() {
-    let timesTriggered = 0
+      timesTriggered++;
+    });
+    expect(timesTriggered).toBe(0);
+    provider.add("First");
+    expect(timesTriggered).toBe(1);
+    provider.add("Second");
+    expect(timesTriggered).toBe(2);
+    provider.add("Third");
+    expect(timesTriggered).toBe(3);
+  });
+  it("emits remove event properly", function() {
+    let timesTriggered = 0;
 
     provider.onDidRemove(function(title) {
       if (timesTriggered === 0) {
-        expect(title).toBe('First')
+        expect(title).toBe("First");
       } else if (timesTriggered === 1) {
-        expect(title).toBe('Second')
+        expect(title).toBe("Second");
       } else if (timesTriggered === 2) {
-        expect(title).toBe('Third')
+        expect(title).toBe("Third");
       } else {
-        expect(false).toBe(true)
+        expect(false).toBe(true);
       }
-      timesTriggered++
-    })
+      timesTriggered++;
+    });
 
-    expect(timesTriggered).toBe(0)
-    provider.remove('First')
-    expect(timesTriggered).toBe(1)
-    provider.remove('Second')
-    expect(timesTriggered).toBe(2)
-    provider.remove('Third')
-    expect(timesTriggered).toBe(3)
-  })
-  it('emits clear event properly', function() {
-    let timesTriggered = 0
+    expect(timesTriggered).toBe(0);
+    provider.remove("First");
+    expect(timesTriggered).toBe(1);
+    provider.remove("Second");
+    expect(timesTriggered).toBe(2);
+    provider.remove("Third");
+    expect(timesTriggered).toBe(3);
+  });
+  it("emits clear event properly", function() {
+    let timesTriggered = 0;
 
     provider.onDidClear(function() {
-      timesTriggered++
-    })
+      timesTriggered++;
+    });
 
-    expect(timesTriggered).toBe(0)
-    provider.clear()
-    expect(timesTriggered).toBe(1)
-    provider.clear()
-    expect(timesTriggered).toBe(2)
-    provider.clear()
-    expect(timesTriggered).toBe(3)
-    provider.clear()
-    expect(timesTriggered).toBe(4)
-  })
-  it('emits destroy event properly', function() {
-    let timesTriggered = 0
+    expect(timesTriggered).toBe(0);
+    provider.clear();
+    expect(timesTriggered).toBe(1);
+    provider.clear();
+    expect(timesTriggered).toBe(2);
+    provider.clear();
+    expect(timesTriggered).toBe(3);
+    provider.clear();
+    expect(timesTriggered).toBe(4);
+  });
+  it("emits destroy event properly", function() {
+    let timesTriggered = 0;
 
     provider.onDidDispose(function() {
-      timesTriggered++
-    })
+      timesTriggered++;
+    });
 
-    expect(timesTriggered).toBe(0)
-    provider.dispose()
-    expect(timesTriggered).toBe(1)
-    provider.dispose()
-    expect(timesTriggered).toBe(1)
-    provider.dispose()
-    expect(timesTriggered).toBe(1)
-    provider.dispose()
-    expect(timesTriggered).toBe(1)
-  })
-})
+    expect(timesTriggered).toBe(0);
+    provider.dispose();
+    expect(timesTriggered).toBe(1);
+    provider.dispose();
+    expect(timesTriggered).toBe(1);
+    provider.dispose();
+    expect(timesTriggered).toBe(1);
+    provider.dispose();
+    expect(timesTriggered).toBe(1);
+  });
+});

--- a/spec/registry-spec.js
+++ b/spec/registry-spec.js
@@ -1,100 +1,106 @@
 /* @flow */
 
-import { it, wait } from 'jasmine-fix'
-import Registry from '../lib/registry'
+import { it, wait } from "jasmine-fix";
+import Registry from "../lib/registry";
 
-describe('Registry', function() {
-  let registry
+describe("Registry", function() {
+  let registry;
 
   beforeEach(function() {
-    registry = new Registry()
-  })
+    registry = new Registry();
+  });
   afterEach(function() {
-    registry.dispose()
-  })
-  function validateOldTiles(oldTitles: Array<{ title: string, duration: string }>, titles: Array<string>) {
-    expect(oldTitles.length).toBe(titles.length)
+    registry.dispose();
+  });
+  function validateOldTiles(
+    oldTitles: Array<{ title: string, duration: string }>,
+    titles: Array<string>
+  ) {
+    expect(oldTitles.length).toBe(titles.length);
 
     titles.forEach(function(title, index) {
-      expect(oldTitles[index].title).toBe(title)
-      expect(oldTitles[index].duration === '1ms' || oldTitles[index].duration === '0ms').toBe(true)
-    })
+      expect(oldTitles[index].title).toBe(title);
+      expect(
+        oldTitles[index].duration === "1ms" ||
+          oldTitles[index].duration === "0ms"
+      ).toBe(true);
+    });
   }
 
-  describe('handling of providers', function() {
-    it('registers providers properly and clears them out when they die', function() {
-      const provider = registry.create()
-      expect(registry.providers.has(provider)).toBe(true)
-      provider.dispose()
-      expect(registry.providers.has(provider)).toBe(false)
-    })
-    it('emits update event properly', function() {
-      const provider = registry.create()
-      const update = jasmine.createSpy('update')
-      registry.onDidUpdate(update)
-      expect(update).not.toHaveBeenCalled()
-      provider.add('Hey')
-      provider.remove('Hey')
-      provider.clear()
-      expect(update).toHaveBeenCalled()
-      expect(update.calls.length).toBe(2)
-    })
-    it('adds and returns sorted titles', async function() {
-      const provider = registry.create()
-      provider.add('Hey')
-      await wait(1)
-      provider.add('Wow')
-      await wait(1)
-      provider.add('Hello')
-      expect(registry.getTilesActive()).toEqual(['Hello', 'Wow', 'Hey'])
-    })
-    it('adds removed ones to history', async function() {
-      const provider = registry.create()
-      provider.add('Boy')
-      await wait(1)
-      provider.add('Hey')
-      expect(registry.getTilesActive()).toEqual(['Hey', 'Boy'])
-      expect(registry.getTilesOld()).toEqual([])
+  describe("handling of providers", function() {
+    it("registers providers properly and clears them out when they die", function() {
+      const provider = registry.create();
+      expect(registry.providers.has(provider)).toBe(true);
+      provider.dispose();
+      expect(registry.providers.has(provider)).toBe(false);
+    });
+    it("emits update event properly", function() {
+      const provider = registry.create();
+      const update = jasmine.createSpy("update");
+      registry.onDidUpdate(update);
+      expect(update).not.toHaveBeenCalled();
+      provider.add("Hey");
+      provider.remove("Hey");
+      provider.clear();
+      expect(update).toHaveBeenCalled();
+      expect(update.calls.length).toBe(2);
+    });
+    it("adds and returns sorted titles", async function() {
+      const provider = registry.create();
+      provider.add("Hey");
+      await wait(1);
+      provider.add("Wow");
+      await wait(1);
+      provider.add("Hello");
+      expect(registry.getTilesActive()).toEqual(["Hello", "Wow", "Hey"]);
+    });
+    it("adds removed ones to history", async function() {
+      const provider = registry.create();
+      provider.add("Boy");
+      await wait(1);
+      provider.add("Hey");
+      expect(registry.getTilesActive()).toEqual(["Hey", "Boy"]);
+      expect(registry.getTilesOld()).toEqual([]);
 
-      provider.remove('Hey')
-      expect(registry.getTilesActive()).toEqual(['Boy'])
-      validateOldTiles(registry.getTilesOld(), ['Hey'])
-    })
-    it('adds cleared ones to history', function() {
-      const provider = registry.create()
-      provider.add('Hello')
-      provider.add('World')
+      provider.remove("Hey");
+      expect(registry.getTilesActive()).toEqual(["Boy"]);
+      validateOldTiles(registry.getTilesOld(), ["Hey"]);
+    });
+    it("adds cleared ones to history", function() {
+      const provider = registry.create();
+      provider.add("Hello");
+      provider.add("World");
 
-      expect(registry.getTilesActive()).toEqual(['Hello', 'World'])
-      expect(registry.getTilesOld()).toEqual([])
+      expect(registry.getTilesActive()).toEqual(["Hello", "World"]);
+      expect(registry.getTilesOld()).toEqual([]);
 
-      provider.clear()
-      expect(registry.getTilesActive()).toEqual([])
-      validateOldTiles(registry.getTilesOld(), ['Hello', 'World'])
-    })
-  })
-  describe('getTilesOld', function() {
-    it('excludes active ones from history', function() {
-      const provider = registry.create()
-      provider.add('Yo CJ')
-      provider.add('Murica')
-      provider.remove('Yo CJ')
-      provider.remove('Murica')
-      provider.add('Yo CJ')
+      provider.clear();
+      expect(registry.getTilesActive()).toEqual([]);
+      validateOldTiles(registry.getTilesOld(), ["Hello", "World"]);
+    });
+  });
+  describe("getTilesOld", function() {
+    it("excludes active ones from history", function() {
+      const provider = registry.create();
+      provider.add("Yo CJ");
+      provider.add("Murica");
+      provider.remove("Yo CJ");
+      provider.remove("Murica");
+      provider.add("Yo CJ");
 
-      validateOldTiles(registry.getTilesOld(), ['Murica'])
-    })
-    it('excludes duplicates and only returns the last one', function() {
-      const provider = registry.create()
+      validateOldTiles(registry.getTilesOld(), ["Murica"]);
+    });
+    it("excludes duplicates and only returns the last one", function() {
+      const provider = registry.create();
 
-      provider.add('Some')
-      provider.add('Things')
-      provider.remove('Some')
-      provider.remove('Things')
-      provider.add('Some')
-      provider.remove('Some')
+      provider.add("Some");
+      provider.add("Things");
+      provider.remove("Some");
+      provider.remove("Things");
+      provider.add("Some");
+      provider.remove("Some");
 
-      validateOldTiles(registry.getTilesOld(), ['Things', 'Some'])
-    })
-  })
-})
+      validateOldTiles(registry.getTilesOld(), ["Things", "Some"]);
+    });
+  });
+});

--- a/spec/registry-spec.js
+++ b/spec/registry-spec.js
@@ -2,6 +2,7 @@
 
 import { it, wait } from "jasmine-fix";
 import Registry from "../lib/registry";
+import type { SignalInternal } from "../lib/types";
 
 describe("Registry", function() {
   let registry;
@@ -12,6 +13,17 @@ describe("Registry", function() {
   afterEach(function() {
     registry.dispose();
   });
+
+  function validateTiles(
+    actual: Array<SignalInternal>,
+    expected: Array<string>
+  ) {
+    expect(actual.length).toBe(expected.length);
+
+    actual.forEach((entry, index) => {
+      expect(entry.title).toBe(expected[index]);
+    });
+  }
   function validateOldTiles(
     oldTitles: Array<{ title: string, duration: string }>,
     titles: Array<string>
@@ -52,18 +64,18 @@ describe("Registry", function() {
       provider.add("Wow");
       await wait(1);
       provider.add("Hello");
-      expect(registry.getTilesActive()).toEqual(["Hello", "Wow", "Hey"]);
+      validateTiles(registry.getTilesActive(), ["Hello", "Wow", "Hey"]);
     });
     it("adds removed ones to history", async function() {
       const provider = registry.create();
       provider.add("Boy");
       await wait(1);
       provider.add("Hey");
-      expect(registry.getTilesActive()).toEqual(["Hey", "Boy"]);
+      validateTiles(registry.getTilesActive(), ["Hey", "Boy"]);
       expect(registry.getTilesOld()).toEqual([]);
 
       provider.remove("Hey");
-      expect(registry.getTilesActive()).toEqual(["Boy"]);
+      validateTiles(registry.getTilesActive(), ["Boy"]);
       validateOldTiles(registry.getTilesOld(), ["Hey"]);
     });
     it("adds cleared ones to history", function() {
@@ -71,11 +83,11 @@ describe("Registry", function() {
       provider.add("Hello");
       provider.add("World");
 
-      expect(registry.getTilesActive()).toEqual(["Hello", "World"]);
+      validateTiles(registry.getTilesActive(), ["Hello", "World"]);
       expect(registry.getTilesOld()).toEqual([]);
 
       provider.clear();
-      expect(registry.getTilesActive()).toEqual([]);
+      validateTiles(registry.getTilesActive(), []);
       validateOldTiles(registry.getTilesOld(), ["Hello", "World"]);
     });
   });

--- a/styles/busy-signal.less
+++ b/styles/busy-signal.less
@@ -6,7 +6,7 @@
 
 busy-signal {
   position: relative;
-  width: 6px;
+  width: 16px;
   height: 100%;
 
   &.idle,
@@ -17,7 +17,7 @@ busy-signal {
       width: 6px;
       height: 6px;
       top: 50%;
-      left: 0;
+      left: 5px;
       margin-top: -3px;
       border-radius: 50%;
 


### PR DESCRIPTION
see https://github.com/facebookarchive/atom-ide-ui/blob/master/docs/busy-signal.md

**Motivation**
atom-ide-ui has been archived and sooner or later should be replaced by something else.
This package is already installed by a lot of atom users so it's a perfect fit to add the busy signal API here.

**TODO**
- [ ] tests
- [ ] support `onlyForFile` and `onDidClick` options

The actual implementation happened in the second commit. In the first commit I updated all dependencies, I hope this does not cause any troubles when reviewing it.
I have also skipped the other options from the `BusySignalOptions` object because IMO they are not worth the hassle (at least for the moment).