### PR TITLE
Fix more than one title modification in Atom-IDE provider

### DIFF
--- a/lib/atom-ide-provider.js
+++ b/lib/atom-ide-provider.js
@@ -37,6 +37,8 @@ export class AtomIdeProvider {
     const busyMessage = {
       setTitle: (newTitle: string) => {
         provider.changeTitle(newTitle, title);
+        // Cache the current title for consecutive title changes
+        title = newTitle
       },
       dispose: () => {
         provider.dispose();

--- a/spec/atom-ide-provider-spec.js
+++ b/spec/atom-ide-provider-spec.js
@@ -68,9 +68,11 @@ describe("Atom IDE Provider", function() {
       validateTiles(registry.getTilesActive(), ["Hi"]);
       msg.setTitle("Howdy");
       validateTiles(registry.getTilesActive(), ["Howdy"]);
+      msg.setTitle("Whatsup")
+      validateTiles(registry.getTilesActive(), ["Whatsup"]);
       msg.dispose();
       validateTiles(registry.getTilesActive(), []);
-      validateOldTiles(registry.getTilesOld(), ["Howdy"], false);
+      validateOldTiles(registry.getTilesOld(), ["Whatsup"], false);
     });
   });
   describe("reportBusyWhile", function() {


### PR DESCRIPTION
When the `message.setTitle()` is called more than once the title will no longer be updated because the previous title is not updated after the function call to the "current"/new title.

The use case for updating the title more than once comes from [ide-mocha](https://atom.io/packages/ide-mocha) which updates the busy spinner with percentage and absolute count of tests executed after every test case.