### PR TITLE
fixed outdated registerElement

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -92,7 +92,7 @@ export class SignalElement extends HTMLElement {
   }
 }
 
-const element = document.registerElement("busy-signal", {
+const element = customElements.define("busy-signal", {
   prototype: SignalElement.prototype
 });
 


### PR DESCRIPTION
I used atom a lot and since it's sunset upset i switched to pulsar  but many packages i used to use are outdated so i am going to fix some of them and this one had many updates but for now i only fixed one. "registerElement" changed to "define" so i just changed that for now.