### PR TITLE
use customElements.define

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -15,8 +15,7 @@ export class SignalElement extends HTMLElement {
   activatedLast: ?number;
   deactivateTimer: ?TimeoutID;
 
-  constructor() {
-    super();
+  connectedCallback() {
     this.update([], []);
     this.classList.add("inline-block");
   }
@@ -93,7 +92,6 @@ export class SignalElement extends HTMLElement {
   }
 }
 
-const element = undefined;
 customElements.define("busy-signal", SignalElement);
 
-export default element;
+export default SignalElement;

--- a/lib/element.js
+++ b/lib/element.js
@@ -15,7 +15,8 @@ export class SignalElement extends HTMLElement {
   activatedLast: ?number;
   deactivateTimer: ?TimeoutID;
 
-  createdCallback() {
+  constructor() {
+    super();
     this.update([], []);
     this.classList.add("inline-block");
   }
@@ -92,8 +93,7 @@ export class SignalElement extends HTMLElement {
   }
 }
 
-const element = document.registerElement("busy-signal", {
-  prototype: SignalElement.prototype
-});
+const element = undefined;
+customElements.define("busy-signal", SignalElement);
 
 export default element;


### PR DESCRIPTION
Untested, but based on https://github.com/WebReflection/document-register-element#whats-new-in-custom-elements-v1
 this should work. (General explanation of customElements: https://javascript.info/custom-elements)

Also, based on https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement, document.registerElement returns `undefined`.

Fixes #91
Fixes #93